### PR TITLE
removes close button on evidence manager

### DIFF
--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -81,7 +81,6 @@ void EvidenceManager::wireUi() {
   connect(ui->editFiltersButton, btnClicked, this, &EvidenceManager::openFiltersMenu);
   connect(ui->filterTextBox, &QLineEdit::returnPressed, this,
           &EvidenceManager::applyFilterButtonClicked);
-  connect(ui->closeFormButton, btnClicked, this, &EvidenceManager::close);
 
   connect(filterForm, &EvidenceFilterForm::evidenceSet, this, &EvidenceManager::applyFilterForm);
   connect(ui->evidenceTable, &QTableWidget::currentCellChanged, this,
@@ -129,8 +128,6 @@ void EvidenceManager::deleteEvidenceButtonClicked() {
     else {
       loadEvidence();
     }
-
-    ui->closeFormButton->setEnabled(true);
   }
 }
 
@@ -243,7 +240,6 @@ void EvidenceManager::refreshRow(int row) {
 
 void EvidenceManager::setActionButtonsEnabled(bool enabled) {
   enableEvidenceButtons(enabled);
-  ui->closeFormButton->setEnabled(enabled);
 }
 
 void EvidenceManager::enableEvidenceButtons(bool enabled) {
@@ -306,7 +302,8 @@ void EvidenceManager::onUploadComplete() {
     }
     QMessageBox::warning(this, "Cannot Submit Evidence",
                          "Upload failed: Network error. Check your connection and try again.\n"
-                         "(Error: " + uploadAssetReply->errorString() + ")");
+                         "(Error: " +
+                             uploadAssetReply->errorString() + ")");
   }
   else {
     try {
@@ -324,7 +321,6 @@ void EvidenceManager::onUploadComplete() {
   // one thing we might want to record: evidence uuid... not sure why we'd need it though.
   submitButton->stopAnimation();
 
-  ui->closeFormButton->setEnabled(true);
   tidyReply(&uploadAssetReply);
 }
 

--- a/src/forms/evidence/evidencemanager.h
+++ b/src/forms/evidence/evidencemanager.h
@@ -30,6 +30,10 @@ struct EvidenceRow {
   QTableWidgetItem* dateSubmitted;
 };
 
+/**
+ * @brief The EvidenceManager class represents the Evidence Manager window that is shown
+ * when selecting "View Accumulated Evidence."
+ */
 class EvidenceManager : public QDialog {
   Q_OBJECT
 
@@ -38,46 +42,75 @@ class EvidenceManager : public QDialog {
   ~EvidenceManager();
 
  protected:
+  /// closeEvent extends QDialog's closeEvent. Clears the evidenceEditor after closing.
   void closeEvent(QCloseEvent* event) override;
 
  private:
+  /// wireUi connects UI elements together
   void wireUi();
 
+  /// saveData stores any edits in evidence view. Deprecated (edits no longer available)
   bool saveData();
+  /// loadEvidence retrieves data from the database and renders the evidence table
   void loadEvidence();
+  /// setActionButtonsEnabled enables the delete/submit ui buttons
   void setActionButtonsEnabled(bool enabled);
+  /// buildBaseEvidenceRow constructs a basic evidence row (fields and formatting, no data applied)
   EvidenceRow buildBaseEvidenceRow(qint64 evidenceID);
+  /// refreshRow updates the indicated row (0-based) with updated (database) data.
   void refreshRow(int row);
+  /// setRowText writes data the indicated row (0-based) based on the given model
   void setRowText(int row, const model::Evidence& model);
+  ///enableEvidenceButtons enables the delete/submit ui buttons
   void enableEvidenceButtons(bool enable);
 
+  /// showEvent extends QDialog's showEvent. Resets the applied filters.
   void showEvent(QShowEvent* evt) override;
+  /// selectedRowEvidenceID is a small helper to get the evidence id for the currently selected row.
   qint64 selectedRowEvidenceID();
 
  signals:
+  /**
+   * @brief evidenceChanged is emitted when a user changes the selection in the evidence table
+   * @param evidenceID the evidence ID of the now-selected evidence
+   * @param readonly True if this evidence can be edited. False otherwise.
+   */
   void evidenceChanged(quint64 evidenceID, bool readonly);
 
  private slots:
+  /// submitEvidenceButtonClicked recieves the submit button clicked event
   void submitEvidenceButtonClicked();
+  /// deleteEvidenceButtonClicked recieves the delete button clicked event
   void deleteEvidenceButtonClicked();
+  /// applyFilterButtonClicked recieves the apply filter button clicked event
   void applyFilterButtonClicked();
+  /// resetFilterButtonClicked recieves the reset filter button clicked event
   void resetFilterButtonClicked();
+  /// applyFilterForm updates the filter textbox to reflect the filter options chosen in the filter
+  /// menu
   void applyFilterForm(const EvidenceFilters& filter);
+  /// openFiltersMenu opens the filter menu with the current filters applied
   void openFiltersMenu();
 
+  /// onRowChanged recieves the event from the evidence table rowChange signal
   void onRowChanged(int currentRow, int currentColumn, int previousRow, int previousColumn);
+  /// onUploadComplete is triggered when the upload response has been received.
   void onUploadComplete();
 
  private:
   Ui::EvidenceManager* ui;
-  EvidenceEditor* evidenceEditor;
-  EvidenceFilterForm* filterForm;
-  LoadingButton* submitButton;
 
+  /// db is a (shared) reference to the local database instance. Not to be deleted.
   DatabaseConnection* db;
 
   QNetworkReply* uploadAssetReply = nullptr;
   qint64 evidenceIDForRequest;
+
+  // UI Elements
+  EvidenceEditor* evidenceEditor;
+  EvidenceFilterForm* filterForm;
+  LoadingButton* submitButton;
+
 };
 
 #endif  // EVIDENCEMANAGER_H

--- a/src/forms/evidence/evidencemanager.ui
+++ b/src/forms/evidence/evidencemanager.ui
@@ -26,63 +26,23 @@
    <string>Evidence Manager</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="5" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="5" column="1">
     <widget class="QPushButton" name="deleteEvidenceButton">
      <property name="text">
       <string>Delete</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2" colspan="2">
-    <widget class="QLineEdit" name="filterTextBox"/>
-   </item>
-   <item row="0" column="4">
-    <widget class="QPushButton" name="applyFilterButton">
-     <property name="text">
-      <string>Apply</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="5">
-    <widget class="QPushButton" name="closeFormButton">
-     <property name="text">
-      <string>Close</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="5">
-    <widget class="QPushButton" name="submitEvidenceButton">
-     <property name="text">
-      <string>Submit</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="5">
-    <widget class="QPushButton" name="resetFilterButton">
-     <property name="text">
-      <string>Reset</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QPushButton" name="editFiltersButton">
-     <property name="text">
-      <string>Edit Filters</string>
      </property>
      <property name="autoDefault">
       <bool>false</bool>
@@ -99,6 +59,39 @@
      </property>
      <property name="text">
       <string>_evidenceEditorPlaceholder</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="QPushButton" name="applyFilterButton">
+     <property name="text">
+      <string>Apply</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="5">
+    <widget class="QPushButton" name="resetFilterButton">
+     <property name="text">
+      <string>Reset</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2" colspan="2">
+    <widget class="QLineEdit" name="filterTextBox"/>
+   </item>
+   <item row="0" column="1">
+    <widget class="QPushButton" name="editFiltersButton">
+     <property name="text">
+      <string>Edit Filters</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -184,18 +177,15 @@
      </column>
     </widget>
    </item>
-   <item row="5" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="5" column="5">
+    <widget class="QPushButton" name="submitEvidenceButton">
+     <property name="text">
+      <string>Submit</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
+     <property name="autoDefault">
+      <bool>false</bool>
      </property>
-    </spacer>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
# Remove close button on evidence manager

This PR simply removes the close button, instead requiring the user to exit via the traffic lights. Note: hotkey support for closing windows will be applied in a separate PR.

Addresses Issue: #8

## Meeting License Requirements

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
