### PR TITLE
Remove the ability to pause an operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,9 @@ To specify a shortcut pattern, simply decide on what set of modifier keys you wa
 
 E.g. `Ctrl+Shift+p`
 
-## Switching and Pausing Operations
+## Switching Operations
 
-Evidence is tied to an operation, and when an operation is paused, or inactive, then the hotkey commands will not work. It may be useful to pause an operation (within this application) once you know you will not be taking additional screenshots. Simply navigate to `Select Operation` > `Pause Operation` to pause an operation, and go to the same place (now called `Enable Operation`) to resume this application. Note: pausing an operation a really more of a pause of this application. You can still use the AShirt website. However, when switching operations, if you were previously in a paused state, you will remain in a paused state.
-
-To change operations, similarly to pause operation, navigate to `Select Operation` and choose one of the operations exposed in the list. If the operation you are looking for is not in the list, try pressing the `Refresh Operations`, or check with the operation owner to ensure that you have write access to that operation.
+To change operations, navigate to `Select Operation` and choose one of the operations exposed in the list. If the operation you are looking for is not in the list, try pressing the `Refresh Operations`, or check with the operation owner to ensure that you have write access to that operation.
 
 ## Managing Evidence
 

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -29,14 +29,12 @@ class AppSettings : public QObject {
 
   const char *opSlugSetting = "operation/slug";
   const char *opNameSetting = "operation/name";
-  const char *opPausedSetting = "operation/paused";
 
   AppSettings() : QObject(nullptr) {}
 
  public:
  signals:
   void onOperationUpdated(QString operationSlug, QString operationName);
-  void onOperationStateChanged(bool isPaused);
   void onSettingsSynced();
 
  public:
@@ -53,15 +51,5 @@ class AppSettings : public QObject {
   }
   QString operationSlug() { return settings.value(opSlugSetting).toString(); }
   QString operationName() { return settings.value(opNameSetting).toString(); }
-
-  void setOperationPaused(bool paused) {
-    settings.setValue(opPausedSetting, paused);
-    emit onOperationStateChanged(paused);
-  }
-  bool toggleOperationPaused() {
-    setOperationPaused(!isOperationPaused());
-    return isOperationPaused();
-  }
-  bool isOperationPaused() { return settings.value(opPausedSetting).toBool(); }
 };
 #endif  // APPSETTINGS_H

--- a/src/hotkeymanager.cpp
+++ b/src/hotkeymanager.cpp
@@ -40,14 +40,12 @@ void HotkeyManager::hotkeyTriggered(size_t hotkeyIndex) {
 
 void HotkeyManager::updateHotkeys() {
   hotkeyManager->unregisterAllHotkeys();
-  if (!AppSettings::getInstance().isOperationPaused()) {
-    auto regKey = [this](QString combo, GlobalHotkeyEvent evt){
-      if (combo != "") {
-        registerKey(combo, evt);
-      }
-    };
-    regKey(AppConfig::getInstance().screenshotShortcutCombo, ACTION_CAPTURE_AREA);
-    regKey(AppConfig::getInstance().captureWindowShortcut, ACTION_CAPTURE_WINDOW);
-    regKey(AppConfig::getInstance().captureCodeblockShortcut, ACTION_CAPTURE_CODEBLOCK);
-  }
+  auto regKey = [this](QString combo, GlobalHotkeyEvent evt) {
+    if (combo != "") {
+      registerKey(combo, evt);
+    }
+  };
+  regKey(AppConfig::getInstance().screenshotShortcutCombo, ACTION_CAPTURE_AREA);
+  regKey(AppConfig::getInstance().captureWindowShortcut, ACTION_CAPTURE_WINDOW);
+  regKey(AppConfig::getInstance().captureCodeblockShortcut, ACTION_CAPTURE_CODEBLOCK);
 }

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -90,7 +90,6 @@ TrayManager::~TrayManager() {
   cleanChooseOpSubmenu();  // must be done before deleting chooseOpSubmenu/action
 
   delete chooseOpStatusAction;
-  delete pauseOperationAction;
   delete refreshOperationListAction;
   delete chooseOpSubmenu;
 
@@ -120,8 +119,6 @@ void TrayManager::wireUi() {
 
   connect(&NetMan::getInstance(), &NetMan::operationListUpdated, this,
           &TrayManager::onOperationListUpdated);
-  connect(&AppSettings::getInstance(), &AppSettings::onOperationStateChanged, this,
-          &TrayManager::setActiveOperationLabel);
   connect(&AppSettings::getInstance(), &AppSettings::onOperationUpdated, this,
           &TrayManager::setActiveOperationLabel);
 }
@@ -173,16 +170,8 @@ void TrayManager::createActions() {
     NetMan::getInstance().refreshOperationsList();
   });
 
-  pauseOperationAction = new QAction(this);
-  connect(pauseOperationAction, &QAction::triggered, [this] {
-    AppSettings::getInstance().toggleOperationPaused();
-    hotkeyManager->updateHotkeys();
-  });
-
   chooseOpSubmenu->addAction(chooseOpStatusAction);
   chooseOpSubmenu->addAction(refreshOperationListAction);
-  chooseOpSubmenu->addSeparator();
-  chooseOpSubmenu->addAction(pauseOperationAction);
   chooseOpSubmenu->addSeparator();
 }
 
@@ -231,13 +220,9 @@ void TrayManager::onScreenshotCaptured(const QString& path) {
 
 void TrayManager::setActiveOperationLabel() {
   auto opName = AppSettings::getInstance().operationName();
-  auto isPaused = AppSettings::getInstance().isOperationPaused();
 
-  pauseOperationAction->setText(tr(isPaused ? "Enable Operation" : "Pause Operation"));
-
-  QString opLabel = tr(isPaused ? "Paused" : "Active");
-  opLabel += tr(" Operation: ");
-  opLabel += (opName == "") ? QString(tr("<None>")) : QString(opName);
+  QString opLabel = tr("Operation: ");
+  opLabel += (opName == "") ? tr("<None>") : opName;
 
   currentOperationMenuAction->setText(opLabel);
 }

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -67,7 +67,6 @@ class TrayManager : public QDialog {
   void cleanChooseOpSubmenu();
   QMenu *chooseOpSubmenu;
   QAction *chooseOpStatusAction;
-  QAction *pauseOperationAction;
   QAction *refreshOperationListAction;
   QAction *selectedAction = nullptr;  // note: do not delete; for reference only
   std::vector<QAction *> allOperationActions;


### PR DESCRIPTION
Address issue: #14 

Simply removes the action, ability, and references to the ability to pause an operation.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
