### PR TITLE
Remove deletion of spacers

### DIFF
--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -53,7 +53,6 @@ Settings::~Settings() {
   delete testConnectionButton;
   delete eviRepoBrowseButton;
   delete buttonBox;
-  delete spacer;
 
   delete gridLayout;
 


### PR DESCRIPTION
This fixes an issue on quitting the application where a segfault would arise due to a double free.

Background: 

A Qt layout takes ownership of any item added to it. Since QSpacerItem is an item, it becomes managed by QtLayout, and as a result, the layout is responsible for deleting the item. This means we cannot delete spacers (or any other `*Item` that would be added to a layout) during  the form destructor. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
