### PR TITLE
Easier Hotkey Assignment

### DIFF
--- a/ascreen.pro
+++ b/ascreen.pro
@@ -22,6 +22,7 @@ SOURCES += \
     src/components/aspectratio_pixmap_label/imageview.cpp \
     src/components/code_editor/codeblockview.cpp \
     src/components/code_editor/codeeditor.cpp \
+    src/components/custom_keyseq_edit/singlestrokekeysequenceedit.cpp \
     src/components/error_view/errorview.cpp \
     src/components/evidence_editor/evidenceeditor.cpp \
     src/components/evidencepreview.cpp \
@@ -49,6 +50,7 @@ HEADERS += \
     src/components/aspectratio_pixmap_label/imageview.h \
     src/components/code_editor/codeblockview.h \
     src/components/code_editor/codeeditor.h \
+    src/components/custom_keyseq_edit/singlestrokekeysequenceedit.h \
     src/components/error_view/errorview.h \
     src/components/evidence_editor/deleteevidenceresponse.h \
     src/components/evidence_editor/evidenceeditor.h \

--- a/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.cpp
+++ b/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.cpp
@@ -1,7 +1,7 @@
 #include "singlestrokekeysequenceedit.h"
 
 SingleStrokeKeySequenceEdit::SingleStrokeKeySequenceEdit(QWidget* parent) : QKeySequenceEdit(parent){
-
+  this->installEventFilter(this);
 }
 
 // Note: this may prevent editingFinished from firing
@@ -9,4 +9,18 @@ void SingleStrokeKeySequenceEdit::keyPressEvent(QKeyEvent * evt) {
   QKeySequenceEdit::keyPressEvent(evt);
 
   setKeySequence(keySequence()[0]);
+  previousSequence = keySequence(); // update the saved sequence once one has been set
+}
+
+bool SingleStrokeKeySequenceEdit::eventFilter(QObject *object, QEvent *event) {
+  if (event->type() == QEvent::FocusIn) {
+    // save + remove the current sequence to provide the user with a prompt
+    previousSequence = keySequence();
+    clear();
+  }
+  if (event->type() == QEvent::FocusOut) {
+    // restore the current/saved sequence
+    setKeySequence(previousSequence);
+  }
+  return QKeySequenceEdit::eventFilter(object, event);
 }

--- a/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.cpp
+++ b/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.cpp
@@ -1,0 +1,12 @@
+#include "singlestrokekeysequenceedit.h"
+
+SingleStrokeKeySequenceEdit::SingleStrokeKeySequenceEdit(QWidget* parent) : QKeySequenceEdit(parent){
+
+}
+
+// Note: this may prevent editingFinished from firing
+void SingleStrokeKeySequenceEdit::keyPressEvent(QKeyEvent * evt) {
+  QKeySequenceEdit::keyPressEvent(evt);
+
+  setKeySequence(keySequence()[0]);
+}

--- a/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.h
+++ b/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.h
@@ -1,0 +1,18 @@
+#ifndef SINGLESTROKEKEYSEQUENCEEDIT_H
+#define SINGLESTROKEKEYSEQUENCEEDIT_H
+
+#include <QObject>
+#include <QKeySequenceEdit>
+#include <QKeyEvent>
+
+class SingleStrokeKeySequenceEdit : public QKeySequenceEdit
+{
+ public:
+  SingleStrokeKeySequenceEdit(QWidget* parent=nullptr);
+
+ protected:
+  void keyPressEvent(QKeyEvent *evt) override;
+
+};
+
+#endif // SINGLESTROKEKEYSEQUENCEEDIT_H

--- a/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.h
+++ b/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.h
@@ -13,6 +13,10 @@ class SingleStrokeKeySequenceEdit : public QKeySequenceEdit
  protected:
   void keyPressEvent(QKeyEvent *evt) override;
 
+  bool eventFilter(QObject *object, QEvent *event) override;
+
+ private:
+  QKeySequence previousSequence;
 };
 
 #endif // SINGLESTROKEKEYSEQUENCEEDIT_H

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -176,6 +176,7 @@ void Settings::wireUi() {
 void Settings::showEvent(QShowEvent *evt) {
   QDialog::showEvent(evt);
   AppConfig &inst = AppConfig::getInstance();
+  eviRepoTextBox->setFocus(); //setting focus to prevent retaining focus for macs
 
   // reset the form in case a user left junk in the text boxes and pressed "cancel"
   eviRepoTextBox->setText(inst.evidenceRepo);

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -200,7 +200,7 @@ void Settings::closeEvent(QCloseEvent *event) {
 
 void Settings::onCancelClicked() {
   stopReply(&currentTestReply);
-  close();
+  reject();
 }
 
 void Settings::onSaveClicked() {

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -15,6 +15,7 @@
 #include "helpers/stopreply.h"
 #include "helpers/ui_helpers.h"
 #include "hotkeymanager.h"
+#include "components/custom_keyseq_edit/singlestrokekeysequenceedit.h"
 
 Settings::Settings(HotkeyManager *hotkeyManager, QWidget *parent) : QDialog(parent) {
   buildUi();
@@ -78,10 +79,10 @@ void Settings::buildUi() {
   secretKeyTextBox = new QLineEdit(this);
   hostPathTextBox = new QLineEdit(this);
   captureAreaCmdTextBox = new QLineEdit(this);
-  captureAreaShortcutTextBox = new QLineEdit(this);
+  captureAreaShortcutTextBox = new SingleStrokeKeySequenceEdit(this);
   captureWindowCmdTextBox = new QLineEdit(this);
-  captureWindowShortcutTextBox = new QLineEdit(this);
-  recordCodeblockShortcutTextBox = new QLineEdit(this);
+  captureWindowShortcutTextBox = new SingleStrokeKeySequenceEdit(this);
+  recordCodeblockShortcutTextBox = new SingleStrokeKeySequenceEdit(this);
   eviRepoBrowseButton = new QPushButton("Browse", this);
   testConnectionButton = new LoadingButton("Test Connection", this);
   buttonBox = new QDialogButtonBox(this);
@@ -166,18 +167,10 @@ void Settings::buildUi() {
 }
 
 void Settings::wireUi() {
-  connect(buttonBox, &QDialogButtonBox::clicked, this, &Settings::routeButtonPress);
+  connect(buttonBox, &QDialogButtonBox::accepted, this, &Settings::onSaveClicked);
+  connect(buttonBox, &QDialogButtonBox::rejected, this, &Settings::onCancelClicked);
   connect(testConnectionButton, &QPushButton::clicked, this, &Settings::onTestConnectionClicked);
   connect(eviRepoBrowseButton, &QPushButton::clicked, this, &Settings::onBrowseClicked);
-}
-
-void Settings::routeButtonPress(QAbstractButton *btn) {
-  if (buttonBox->button(QDialogButtonBox::Save) == btn) {
-    onSaveClicked();
-  }
-  else if (buttonBox->button(QDialogButtonBox::Cancel) == btn) {
-    onCancelClicked();
-  }
 }
 
 void Settings::showEvent(QShowEvent *evt) {
@@ -190,10 +183,10 @@ void Settings::showEvent(QShowEvent *evt) {
   secretKeyTextBox->setText(inst.secretKey);
   hostPathTextBox->setText(inst.apiURL);
   captureAreaCmdTextBox->setText(inst.screenshotExec);
-  captureAreaShortcutTextBox->setText(inst.screenshotShortcutCombo);
+  captureAreaShortcutTextBox->setKeySequence(QKeySequence::fromString(inst.screenshotShortcutCombo));
   captureWindowCmdTextBox->setText(inst.captureWindowExec);
-  captureWindowShortcutTextBox->setText(inst.captureWindowShortcut);
-  recordCodeblockShortcutTextBox->setText(inst.captureCodeblockShortcut);
+  captureWindowShortcutTextBox->setKeySequence(QKeySequence::fromString(inst.captureWindowShortcut));
+  recordCodeblockShortcutTextBox->setKeySequence(QKeySequence::fromString(inst.captureCodeblockShortcut));
 
   // re-enable form
   connStatusLabel->setText("");
@@ -221,10 +214,10 @@ void Settings::onSaveClicked() {
   inst.secretKey = secretKeyTextBox->text();
   inst.apiURL = hostPathTextBox->text();
   inst.screenshotExec = captureAreaCmdTextBox->text();
-  inst.screenshotShortcutCombo = captureAreaShortcutTextBox->text();
+  inst.screenshotShortcutCombo = captureAreaShortcutTextBox->keySequence().toString();
   inst.captureWindowExec = captureWindowCmdTextBox->text();
-  inst.captureWindowShortcut = captureWindowShortcutTextBox->text();
-  inst.captureCodeblockShortcut = recordCodeblockShortcutTextBox->text();
+  inst.captureWindowShortcut = captureWindowShortcutTextBox->keySequence().toString();
+  inst.captureCodeblockShortcut = recordCodeblockShortcutTextBox->keySequence().toString();
 
   try {
     inst.writeConfig();

--- a/src/forms/settings/settings.h
+++ b/src/forms/settings/settings.h
@@ -14,6 +14,7 @@
 #include <QNetworkReply>
 #include <QPushButton>
 #include <QSpacerItem>
+#include <QKeySequenceEdit>
 
 #include "components/loading_button/loadingbutton.h"
 #include "hotkeymanager.h"
@@ -43,8 +44,6 @@ class Settings : public QDialog {
   void onSaveClicked();
   /// onCancelClicked handles the discard operation. Used when the "Cancel" button is pressed.
   void onCancelClicked();
-  /// routeButtonPress maps QDialogButtonBox buttons to named buttons.
-  void routeButtonPress(QAbstractButton* btn);
 
  public slots:
   /// showEvent extends the native showEvent handler. Restores the UI to system values.
@@ -83,10 +82,10 @@ class Settings : public QDialog {
   QLineEdit* secretKeyTextBox = nullptr;
   QLineEdit* hostPathTextBox = nullptr;
   QLineEdit* captureAreaCmdTextBox = nullptr;
-  QLineEdit* captureAreaShortcutTextBox = nullptr;
+  QKeySequenceEdit* captureAreaShortcutTextBox = nullptr;
   QLineEdit* captureWindowCmdTextBox = nullptr;
-  QLineEdit* captureWindowShortcutTextBox = nullptr;
-  QLineEdit* recordCodeblockShortcutTextBox = nullptr;
+  QKeySequenceEdit* captureWindowShortcutTextBox = nullptr;
+  QKeySequenceEdit* recordCodeblockShortcutTextBox = nullptr;
   LoadingButton* testConnectionButton = nullptr;
   QPushButton* eviRepoBrowseButton = nullptr;
   QDialogButtonBox* buttonBox = nullptr;


### PR DESCRIPTION
This PR allows hotkeys to be defined simply by entering the text box, and then pressing the desired hotkey. Note: the current hot key is still active, as are all other hotkeys, so re-assigning a hot key to the same value is weird. You should instead just back out of the settings menu to restore the original values.

Addresses Issue #4 

This also corrects an unreported issue where the cancel button would also save data in the setting form. This was introduced when moving away from the Qt UI designer. 

Note: Qt allows multiple key strokes to be assigned to a single shortcut. This works when tying a shortcut to an action. However, this does not work for global hotkeys. As such, I have created a small class to restrict the hotkey to the last single stroke (though the code appears to choose the first stroke, this is effectively equivalent due to how the QKeySequenceEdit works).

Further revised to clear the current shortcut whenever this component gains focus. This is somewhat temporary. If a user leaves focus without providing a new sequence, the old one will be restored. 
Note that this could be a bit buggy in corner cases. The current implementation waits for new keyPressEvents and updates the keySequence. An alternative would be to wait for the keySequenceChanged event, but this will trigger whenever clear is called, which breaks this functionality altogether. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
