### PR TITLE
Allow users to copy the path of a file to the clipboard

### DIFF
--- a/src/forms/evidence/evidencemanager.h
+++ b/src/forms/evidence/evidencemanager.h
@@ -4,9 +4,9 @@
 #ifndef EVIDENCEMANAGER_H
 #define EVIDENCEMANAGER_H
 
+#include <QAction>
 #include <QDialog>
 #include <QMenu>
-#include <QAction>
 #include <QNetworkReply>
 #include <QTableWidget>
 #include <QTableWidgetItem>
@@ -94,6 +94,9 @@ class EvidenceManager : public QDialog {
   /// onUploadComplete is triggered when the upload response has been received.
   void onUploadComplete();
 
+  /// copyPathTriggered recives the triggered event from the copyPathToClipboardAction
+  void copyPathTriggered();
+
  private:
   /// db is a (shared) reference to the local database instance. Not to be deleted.
   DatabaseConnection* db;
@@ -107,6 +110,7 @@ class EvidenceManager : public QDialog {
 
   QAction* submitEvidenceAction = nullptr;
   QAction* deleteEvidenceAction = nullptr;
+  QAction* copyPathToClipboardAction = nullptr;
 
   // UI Elements
   QGridLayout* gridLayout = nullptr;

--- a/src/helpers/clipboard/clipboardhelper.cpp
+++ b/src/helpers/clipboard/clipboardhelper.cpp
@@ -27,3 +27,8 @@ QPixmap ClipboardHelper::readImage() {
   }
   return data;
 }
+
+void ClipboardHelper::setText(QString text) {
+  auto clipboard = QApplication::clipboard();
+  clipboard->setText(text);
+}

--- a/src/helpers/clipboard/clipboardhelper.h
+++ b/src/helpers/clipboard/clipboardhelper.h
@@ -15,6 +15,7 @@ class ClipboardHelper : public QObject {
  public:
   static QString readPlaintext();
   static QPixmap readImage();
+  static void setText(QString text);
 
  signals:
 };


### PR DESCRIPTION
This PR allows a user to select some evidence from the evidence table, and copy the path of that file to the clipboard.

Addresses Issue: #19 

Also revises the context menu to not show if nothing is selected (choose an operation with no submitted evidence for an easy test)

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
