### PR TITLE
Prevent users from capturing evidence while no operation is set

### DIFF
--- a/src/hotkeymanager.cpp
+++ b/src/hotkeymanager.cpp
@@ -8,11 +8,9 @@
 
 #include "appconfig.h"
 #include "appsettings.h"
-#include "helpers/screenshot.h"
 
-HotkeyManager::HotkeyManager(Screenshot* ss) {
+HotkeyManager::HotkeyManager() {
   hotkeyManager = new UGlobalHotkeys();
-  screenshotTool = ss;
   connect(hotkeyManager, &UGlobalHotkeys::activated, this, &HotkeyManager::hotkeyTriggered);
 }
 
@@ -28,10 +26,10 @@ void HotkeyManager::unregisterKey(GlobalHotkeyEvent evt) {
 
 void HotkeyManager::hotkeyTriggered(size_t hotkeyIndex) {
   if (hotkeyIndex == ACTION_CAPTURE_AREA) {
-    screenshotTool->captureArea();
+    emit captureAreaHotkeyPressed();
   }
   else if (hotkeyIndex == ACTION_CAPTURE_WINDOW) {
-    screenshotTool->captureWindow();
+    emit captureWindowHotkeyPressed();
   }
   else if (hotkeyIndex == ACTION_CAPTURE_CODEBLOCK) {
     emit codeblockHotkeyPressed();

--- a/src/hotkeymanager.h
+++ b/src/hotkeymanager.h
@@ -17,7 +17,7 @@ class HotkeyManager : public QObject {
   Q_OBJECT
 
  public:
-  HotkeyManager(Screenshot* ss);
+  HotkeyManager();
   ~HotkeyManager();
 
   /// GlobalHotkeyEvent provides names for all possible application-global hotkeys
@@ -42,6 +42,10 @@ class HotkeyManager : public QObject {
  signals:
   /// codeblockHotkeyPressed signals when the ACTION_CAPTURE_CODEBLOCK event has been triggered.
   void codeblockHotkeyPressed();
+  /// captureWindowHotkeyPressed signals when the ACTION_CAPTURE_WINDOW event has been triggered.
+  void captureWindowHotkeyPressed();
+  /// captureAreaHotkeyPressed signals when the ACTION_CAPTURE_AREA event has been triggered.
+  void captureAreaHotkeyPressed();
 
  public slots:
   /// updateHotkeys retrives AppConfig data to set known global hotkeys. Removes _all_ (Application)
@@ -53,8 +57,6 @@ class HotkeyManager : public QObject {
   void hotkeyTriggered(size_t hotkeyIndex);
 
  private:
-  /// screenshotTool is a (shared) reference to the ScreenShot object. Not to be deleted.
-  Screenshot* screenshotTool;
   /// hotkeyManager is a reference to the raw hotkey manager, which a 3rd party manages.
   UGlobalHotkeys* hotkeyManager;
 };

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -267,7 +267,7 @@ void TrayManager::onScreenshotCaptured(const QString& path) {
 }
 
 void TrayManager::showNoOperationSetTrayMessage() {
-  trayIcon->showMessage("Unable to Record Evidence", "No Operation has been selected. Please select an operation first.");
+  trayIcon->showMessage("Unable to Record Evidence", "No Operation has been selected. Please select an operation first.",QSystemTrayIcon::Warning);
 }
 
 void TrayManager::setActiveOperationLabel() {

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -51,7 +51,7 @@ TrayManager::TrayManager(DatabaseConnection* db) {
   this->db = db;
 
   screenshotTool = new Screenshot();
-  hotkeyManager = new HotkeyManager(screenshotTool);
+  hotkeyManager = new HotkeyManager();
   hotkeyManager->updateHotkeys();
 
   settingsWindow = new Settings(hotkeyManager, this);
@@ -114,8 +114,13 @@ void TrayManager::cleanChooseOpSubmenu() {
 void TrayManager::wireUi() {
   connect(screenshotTool, &Screenshot::onScreenshotCaptured, this,
           &TrayManager::onScreenshotCaptured);
+
   connect(hotkeyManager, &HotkeyManager::codeblockHotkeyPressed, this,
-          &TrayManager::onCodeblockCapture);
+          &TrayManager::captureCodeblockActionTriggered);
+  connect(hotkeyManager, &HotkeyManager::captureAreaHotkeyPressed, this,
+          &TrayManager::captureAreaActionTriggered);
+  connect(hotkeyManager, &HotkeyManager::captureWindowHotkeyPressed, this,
+          &TrayManager::captureWindowActionTriggered);
 
   connect(&NetMan::getInstance(), &NetMan::operationListUpdated, this,
           &TrayManager::onOperationListUpdated);
@@ -146,10 +151,10 @@ void TrayManager::createActions() {
   currentOperationMenuAction->setEnabled(false);
 
   captureScreenAreaAction = new QAction(tr("Capture Screen Area"), this);
-  connect(captureScreenAreaAction, &QAction::triggered, screenshotTool, &Screenshot::captureArea);
+  connect(captureScreenAreaAction, &QAction::triggered, this, &TrayManager::captureAreaActionTriggered);
 
   captureWindowAction = new QAction(tr("Capture Window"), this);
-  connect(captureWindowAction, &QAction::triggered, screenshotTool, &Screenshot::captureWindow);
+  connect(captureWindowAction, &QAction::triggered, this, &TrayManager::captureWindowActionTriggered);
 
   showEvidenceManagerAction = new QAction(tr("View Accumulated Evidence"), this);
   connect(showEvidenceManagerAction, &QAction::triggered, evidenceManagerWindow, &QWidget::show);
@@ -158,7 +163,7 @@ void TrayManager::createActions() {
   connect(showCreditsAction, &QAction::triggered, creditsWindow, &QWidget::show);
 
   addCodeblockAction = new QAction(tr("Add Codeblock from Clipboard"), this);
-  connect(addCodeblockAction, &QAction::triggered, this, &TrayManager::onCodeblockCapture);
+  connect(addCodeblockAction, &QAction::triggered, this, &TrayManager::captureCodeblockActionTriggered);
 
   chooseOpSubmenu = new QMenu(tr("Select Operation"));
   chooseOpStatusAction = new QAction("Loading operations...", chooseOpSubmenu);
@@ -191,6 +196,18 @@ qint64 TrayManager::createNewEvidence(QString filepath, QString evidenceType) {
     db->setEvidenceTags(tags, evidenceID);
   }
   return evidenceID;
+}
+
+void TrayManager::captureWindowActionTriggered() {
+  screenshotTool->captureWindow();
+}
+
+void TrayManager::captureAreaActionTriggered() {
+  screenshotTool->captureArea();
+}
+
+void TrayManager::captureCodeblockActionTriggered() {
+  onCodeblockCapture();
 }
 
 void TrayManager::onCodeblockCapture() {

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -199,14 +199,26 @@ qint64 TrayManager::createNewEvidence(QString filepath, QString evidenceType) {
 }
 
 void TrayManager::captureWindowActionTriggered() {
+  if(AppSettings::getInstance().operationSlug() == "") {
+    showNoOperationSetTrayMessage();
+    return;
+  }
   screenshotTool->captureWindow();
 }
 
 void TrayManager::captureAreaActionTriggered() {
+  if(AppSettings::getInstance().operationSlug() == "") {
+    showNoOperationSetTrayMessage();
+    return;
+  }
   screenshotTool->captureArea();
 }
 
 void TrayManager::captureCodeblockActionTriggered() {
+  if(AppSettings::getInstance().operationSlug() == "") {
+    showNoOperationSetTrayMessage();
+    return;
+  }
   onCodeblockCapture();
 }
 
@@ -252,6 +264,10 @@ void TrayManager::onScreenshotCaptured(const QString& path) {
   catch (QSqlError& e) {
     std::cout << "could not write to the database: " << e.text().toStdString() << std::endl;
   }
+}
+
+void TrayManager::showNoOperationSetTrayMessage() {
+  trayIcon->showMessage("Unable to Record Evidence", "No Operation has been selected. Please select an operation first.");
 }
 
 void TrayManager::setActiveOperationLabel() {

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -46,6 +46,9 @@ class TrayManager : public QDialog {
   void onScreenshotCaptured(const QString &filepath);
   void setActiveOperationLabel();
   void onCodeblockCapture();
+  void captureAreaActionTriggered();
+  void captureWindowActionTriggered();
+  void captureCodeblockActionTriggered();
 
  private slots:
   void onOperationListUpdated(bool success, const std::vector<dto::Operation> &operations);

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -59,6 +59,7 @@ class TrayManager : public QDialog {
   void wireUi();
   qint64 createNewEvidence(QString filepath, QString evidenceType);
   void spawnGetInfoWindow(qint64 evidenceID);
+  void showNoOperationSetTrayMessage();
 
  private:
   QAction *quitAction;


### PR DESCRIPTION
This PR addresses the scenario where a user captures evidence without having an operation set. Instead of actually recording the evidence, a popup will spawn next to the tray indicating that an operation must be set first. 

Addresses Issue #25 

Changes:

* The Hotkey manager now only spawns signals. It does not act on the key events directly. 
* The tray manager now has 3 new slots to capture evidence (one of each type), each of which verifies that an operation  is set
 
Testing this change:

You'll likely need to update your settings file (check the readme for the likely location), or install on a machine that has never had this project. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
