### PR TITLE
Embed version information from automatic build into executable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,6 @@ jobs:
         os: [macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    env:
-      TAG_REF: ${{GITHUB_REF}}
-      COMMIT_SHA: ${GITHUB_SHA:8}
 
     steps:
     - name: Set artifact name

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,9 @@ jobs:
         os: [macos-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+    env:
+      TAG: ${GITHUB_REF}
+      COMMIT_SHA: ${needs.store-sha8.outputs.sha8}
 
     steps:
     - name: Set artifact name

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,8 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
-      TAG_REF: ${GITHUB_REF}
-      COMMIT_SHA: ${GITHUB_SHA::8}
+      TAG_REF: ${{GITHUB_REF}}
+      COMMIT_SHA: ${GITHUB_SHA:8}
 
     steps:
     - name: Set artifact name

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,8 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
-      TAG: ${GITHUB_REF}
-      COMMIT_SHA: ${needs.store-sha8.outputs.sha8}
+      TAG: $GITHUB_REF
+      COMMIT_SHA: "${GITHUB_SHA::8}"
 
     steps:
     - name: Set artifact name

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,8 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     env:
-      TAG: $GITHUB_REF
-      COMMIT_SHA: "${GITHUB_SHA::8}"
+      TAG_REF: ${GITHUB_REF}
+      COMMIT_SHA: ${GITHUB_SHA::8}
 
     steps:
     - name: Set artifact name

--- a/ashirt.pro
+++ b/ashirt.pro
@@ -11,10 +11,8 @@ CONFIG += c++11
 DEFINES += QT_DEPRECATED_WARNINGS
 
 # App version number
-#VERSION_TAG_PLAIN = $$getenv(GITHUB_REF)
-#COMMIT_HASH_PLAIN = $$getenv(GITHUB_SHA)
-VERSION_TAG_PLAIN = blahblah_tags/v1.2.3
-COMMIT_HASH_PLAIN = cafebabe
+VERSION_TAG_PLAIN = $$getenv(GITHUB_REF)
+COMMIT_HASH_PLAIN = $$getenv(GITHUB_SHA)
 
 !contains(VERSION_TAG_PLAIN, .*tags/v.*) {
   message("Ref appears to not be a tag (Value: $$VERSION_TAG_PLAIN). Using non-version instead.")

--- a/ashirt.pro
+++ b/ashirt.pro
@@ -11,25 +11,24 @@ CONFIG += c++11
 DEFINES += QT_DEPRECATED_WARNINGS
 
 # App version number
-VERSION_TAG_PLAIN = $$getenv(TAG)
-equals(VERSION_TAG_PLAIN, "") {
-  message(No Tag specified. Check if TAG environment variable is set.)
-  VERSION_TAG_PLAIN = Unknown-Version
+VERSION_TAG_PLAIN = $$getenv(TAG_REF)
+
+!contains(VERSION_TAG_PLAIN, .*tags/v.*) {
+  message("Ref appears to not be a tag (Value: $$VERSION_TAG_PLAIN) -- using SHA isntead.")
+  VERSION_TAG_PLAIN = $$getenv(COMMIT_SHA)
 }
 
-VERSION_COMMIT_HASH_PLAIN = $$getenv(COMMIT_SHA)
-equals(VERSION_COMMIT_HASH_PLAIN, "") {
-  message("No commit hash specified. Check if COMMIT_SHA environment variable is set.")
-  VERSION_COMMIT_HASH_PLAIN = Unknown-SHA
+equals(VERSION_TAG_PLAIN, "") {
+  message("No tag or commit hash specified. Check if TAG_REF or COMMIT_SHA environment variables are set.")
+  VERSION_TAG_PLAIN = Unknown
 }
+
 
 VERSION_TAG=\\\"$$VERSION_TAG_PLAIN\\\"
-VERSION_COMMIT_HASH = \\\"$$VERSION_COMMIT_HASH_PLAIN\\\"
 
-message(Building version [$$VERSION_TAG_PLAIN] using commit [$$VERSION_COMMIT_HASH_PLAIN])
+message(Building version [$$VERSION_TAG_PLAIN])
 
-DEFINES += "VERSION_TAG=$$VERSION_TAG"\
-       "VERSION_COMMIT_HASH=$$VERSION_COMMIT_HASH"
+DEFINES += "VERSION_TAG=$$VERSION_TAG"
 
 INCLUDEPATH += src
 

--- a/ashirt.pro
+++ b/ashirt.pro
@@ -11,24 +11,29 @@ CONFIG += c++11
 DEFINES += QT_DEPRECATED_WARNINGS
 
 # App version number
-VERSION_TAG_PLAIN = $$getenv(TAG_REF)
+#VERSION_TAG_PLAIN = $$getenv(GITHUB_REF)
+#COMMIT_HASH_PLAIN = $$getenv(GITHUB_SHA)
+VERSION_TAG_PLAIN = blahblah_tags/v1.2.3
+COMMIT_HASH_PLAIN = cafebabe
 
 !contains(VERSION_TAG_PLAIN, .*tags/v.*) {
-  message("Ref appears to not be a tag (Value: $$VERSION_TAG_PLAIN) -- using SHA isntead.")
-  VERSION_TAG_PLAIN = $$getenv(COMMIT_SHA)
+  message("Ref appears to not be a tag (Value: $$VERSION_TAG_PLAIN). Using non-version instead.")
+  VERSION_TAG_PLAIN = 0.0.0-Unversioned
 }
 
-equals(VERSION_TAG_PLAIN, "") {
-  message("No tag or commit hash specified. Check if TAG_REF or COMMIT_SHA environment variables are set.")
-  VERSION_TAG_PLAIN = Unknown
+equals(COMMIT_HASH_PLAIN, "") {
+  message("commit hash specified. Please ensure GITHUB_SHA environment variable is set.")
+  COMMIT_HASH_PLAIN = Unknown
 }
 
 
-VERSION_TAG=\\\"$$VERSION_TAG_PLAIN\\\"
+VERSION_TAG = \\\"$$VERSION_TAG_PLAIN\\\"
+COMMIT_HASH = \\\"$$COMMIT_HASH_PLAIN\\\"
 
 message(Building version [$$VERSION_TAG_PLAIN])
 
-DEFINES += "VERSION_TAG=$$VERSION_TAG"
+DEFINES += "VERSION_TAG=$$VERSION_TAG" \
+           "COMMIT_HASH=$$COMMIT_HASH"
 
 INCLUDEPATH += src
 

--- a/ashirt.pro
+++ b/ashirt.pro
@@ -10,10 +10,26 @@ CONFIG += c++11
 # deprecated API in order to know how to port your code away from it.
 DEFINES += QT_DEPRECATED_WARNINGS
 
-# You can also make your code fail to compile if it uses deprecated APIs.
-# In order to do so, uncomment the following line.
-# You can also select to disable deprecated APIs only up to a certain version of Qt.
-#DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x060000    # disables all the APIs deprecated before Qt 6.0.0
+# App version number
+VERSION_TAG_PLAIN = $$getenv(TAG)
+equals(VERSION_TAG_PLAIN, "") {
+  message(No Tag specified. Check if TAG environment variable is set.)
+  VERSION_TAG_PLAIN = Unknown-Version
+}
+
+VERSION_COMMIT_HASH_PLAIN = $$getenv(COMMIT_SHA)
+equals(VERSION_COMMIT_HASH_PLAIN, "") {
+  message("No commit hash specified. Check if COMMIT_SHA environment variable is set.")
+  VERSION_COMMIT_HASH_PLAIN = Unknown-SHA
+}
+
+VERSION_TAG=\\\"$$VERSION_TAG_PLAIN\\\"
+VERSION_COMMIT_HASH = \\\"$$VERSION_COMMIT_HASH_PLAIN\\\"
+
+message(Building version [$$VERSION_TAG_PLAIN] using commit [$$VERSION_COMMIT_HASH_PLAIN])
+
+DEFINES += "VERSION_TAG=$$VERSION_TAG"\
+       "VERSION_COMMIT_HASH=$$VERSION_COMMIT_HASH"
 
 INCLUDEPATH += src
 

--- a/src/forms/credits/credits.cpp
+++ b/src/forms/credits/credits.cpp
@@ -85,10 +85,14 @@ static QString versionData() {
   auto rawVersion = QString("%1").arg(VERSION_TAG);
   auto tagIndex = rawVersion.indexOf(tagPrefix);
   if (tagIndex == -1) {
-    return "Commit SHA: " + rawVersion;
+    return rawVersion;
   }
 
   return rawVersion.right(rawVersion.size() - (tagIndex + tagPrefix.size()));
+}
+
+static QString CommitHash() {
+  return QString("%1").arg(COMMIT_HASH);
 }
 
 static std::string userGuideUrl = "https://www.github.com/ashirt-client/blob/master/README.md";
@@ -98,6 +102,7 @@ static std::string preambleMarkdown() {
   const std::string lf = "\n\n";  // double linefeed to add in linebreaks in markdown
   // clang-format off
   return "Version: " + versionData().toStdString() +
+         lf + "Commit Hash: " + CommitHash().toStdString() +
          lf + "Copyright " + copyrightDate() + ", Verizon Media" +
          lf + "Licensed under the terms of [MIT](https://github.com/theparanoids/ashirt/blob/master/LICENSE)" +
          lf + "A short user guide can be found " + hyperlinkMd("here", userGuideUrl) +

--- a/src/forms/credits/credits.cpp
+++ b/src/forms/credits/credits.cpp
@@ -80,7 +80,12 @@ static std::string copyrightDate() {
   }
   return rtn;
 }
-static std::string versionData() { return "Beta 1"; }
+static QString versionData() {
+  return QString("%1 (Commit: %2)")
+      .arg(VERSION_COMMIT_HASH)
+      .arg(VERSION_TAG)
+      ;
+}
 
 static std::string userGuideUrl = "https://www.github.com/ashirt-client/blob/master/README.md";
 static std::string reportAnIssueUrl = "https://www.github.com/ashirt-client/issues";
@@ -88,7 +93,7 @@ static std::string reportAnIssueUrl = "https://www.github.com/ashirt-client/issu
 static std::string preambleMarkdown() {
   const std::string lf = "\n\n";  // double linefeed to add in linebreaks in markdown
   // clang-format off
-  return "Version: " + versionData() +
+  return "Version: " + versionData().toStdString() +
          lf + "Copyright " + copyrightDate() + ", Verizon Media" +
          lf + "Licensed under the terms of [MIT](https://github.com/theparanoids/ashirt/blob/master/LICENSE)" +
          lf + "A short user guide can be found " + hyperlinkMd("here", userGuideUrl) +

--- a/src/forms/credits/credits.cpp
+++ b/src/forms/credits/credits.cpp
@@ -81,10 +81,14 @@ static std::string copyrightDate() {
   return rtn;
 }
 static QString versionData() {
-  return QString("%1 (Commit: %2)")
-      .arg(VERSION_COMMIT_HASH)
-      .arg(VERSION_TAG)
-      ;
+  QString tagPrefix = "tags/v";
+  auto rawVersion = QString("%1").arg(VERSION_TAG);
+  auto tagIndex = rawVersion.indexOf(tagPrefix);
+  if (tagIndex == -1) {
+    return "Commit SHA: " + rawVersion;
+  }
+
+  return rawVersion.right(rawVersion.size() - (tagIndex + tagPrefix.size()));
 }
 
 static std::string userGuideUrl = "https://www.github.com/ashirt-client/blob/master/README.md";


### PR DESCRIPTION
This PR updates the ashirt.pro file to include some variables to retrieve the version information from the environment variables, and use these values in the about menu to provide tag/commit versions. This can be paired with Gtihub actions to automatically inject these values from the build process.

Addresses Issue: #26 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
