### PR TITLE
Add minimal support for changing operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ On the first launch, the user must first set up an appropriate configuration. Wh
 | Capture Window Command          | The CLI command to take of a given window, and save to a file                                                                |
 | [Capture Area Command] Shortcut | The key combination used (at a system level) to trigger the capture window command                                           |
 
-Once the above is configured, save the settings and you can now select an operation. Open the tray, and under `Select Operation`, choose an operation to start using the application. (Note: you may need to choose `Refresh Operations` in the submenu)
+Once the above is configured, save the settings and you can now select an operation. Open the tray, and under `Select Operation`, choose an operation to start using the application. Note that whenever you change the host path, the list of operations will be updated
 
 ## Screenshot Commands
 
@@ -78,7 +78,7 @@ E.g. `Ctrl+Shift+p`
 
 ## Switching Operations
 
-To change operations, navigate to `Select Operation` and choose one of the operations exposed in the list. If the operation you are looking for is not in the list, try pressing the `Refresh Operations`, or check with the operation owner to ensure that you have write access to that operation.
+To change operations, navigate to `Select Operation` and choose one of the operations exposed in the list. If the operation you are looking for is not in the list, you can refresh the list by closing and re-opening the tray menu, or check with the operation owner to ensure that you have write access to that operation.
 
 ### Multiple backends
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This application requires taking screenshots from the command line. The applicat
 1. Allow for saving the screenshot to a named file.
 2. Create the file _must_ before the application exits.
 
-Theorectically, any application that satisfies this requirement will work. For Mac, the system command to do this is pre-populated, since this is a standard feature. For Linux, there are a number of screenshot commands, and so none are provided. For Windows, a 3rd party application must be used, as there is currently no way to save a screenshot to a named file.
+Theoretically, any application that satisfies this requirement will work. For Mac, the system command to do this is pre-populated, since this is a standard feature. For Linux, there are a number of screenshot commands, and so none are provided. For Windows, a 3rd party application must be used, as there is currently no way to save a screenshot to a named file.
 
 This tool will replace the above filename with `%file` as noted below:
 
@@ -57,7 +57,7 @@ This tool will replace the above filename with `%file` as noted below:
 | Linux/Gnome | gnome-screenshot -w -f %file | gnome-screenshot -a -f %file | Capture window captures the focused window, rather than allowing a selection; adding the `--delay` flag can help mitigate choosing the wrong window |
 | MacOS X     | screencapture -w %file       | screencapture -s %file       |                                                                                                                                                     |
 
-Note: this application expects a _single, basic command_. While piping output to another command _may_ work, it is not guaranteed. Likewise, providing multiple commands on the same "line" _may_ work, but is also not guaranteed. Offically, both of these techniques are unsupported.
+Note: this application expects a _single, basic command_. While piping output to another command _may_ work, it is not guaranteed. Likewise, providing multiple commands on the same "line" _may_ work, but is also not guaranteed. Officially, both of these techniques are unsupported.
 
 ### Shortcuts
 
@@ -82,7 +82,7 @@ To change operations, navigate to `Select Operation` and choose one of the opera
 
 ### Multiple backends
 
-Some users may end up using this application for multiple backends -- either for testing, or due to multiple communities using the same software. Currently this application does not strongly support swiching backends, though it is possible. To swtich backends, simply enter the new API Key, Secret Key, and Host Path in the settings menu. Note that when switching, it is likely your current selected operation will be removed and you will need to select a new operation.
+Some users may end up using this application for multiple backends -- either for testing, or due to multiple communities using the same software. Currently this application does not strongly support switching backends, though it is possible. To switch backends, simply enter the new API Key, Secret Key, and Host Path in the settings menu. Note that when switching, it is likely your current selected operation will be removed and you will need to select a new operation.
 
 A particular edgecase that is not supported is when multiple backends have the same name for different operations. In these cases, it is incumbent on the user to be vigilant and ensure that the right data goes to the right backend.
 
@@ -113,7 +113,7 @@ Filtering can be done by specifying items in `key:value` format. Multiple filter
 
 When trying to apply both a "before" date and "after" date filter, the system will adjust the times so that the "before" date is always _after_ the "after" date. Meaning, the timespan must be inclusive. For example, a range of "before March" and "after May" (excluding March and April) is not valid, and will be revised to "After March, Before May"
 
-When applying only one date, the range is unbounded on the other end. That is, dates are implicily "from the start of time" to "until the end of time"
+When applying only one date, the range is unbounded on the other end. That is, dates are implicitly "from the start of time" to "until the end of time"
 
 ## Local Files
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ E.g. `Ctrl+Shift+p`
 
 To change operations, navigate to `Select Operation` and choose one of the operations exposed in the list. If the operation you are looking for is not in the list, try pressing the `Refresh Operations`, or check with the operation owner to ensure that you have write access to that operation.
 
+### Multiple backends
+
+Some users may end up using this application for multiple backends -- either for testing, or due to multiple communities using the same software. Currently this application does not strongly support swiching backends, though it is possible. To swtich backends, simply enter the new API Key, Secret Key, and Host Path in the settings menu. Note that when switching, it is likely your current selected operation will be removed and you will need to select a new operation.
+
+A particular edgecase that is not supported is when multiple backends have the same name for different operations. In these cases, it is incumbent on the user to be vigilant and ensure that the right data goes to the right backend.
+
 ## Managing Evidence
 
 Previous evidence can be reviewed by navigating to `View Accumulated Evidence`, which will present a screen showing evidence for the current operation. Selecting a row in the evidence list will show:
@@ -128,7 +134,7 @@ The above paths reference some variables. Some of these values change depending 
 | Path Variable            | Notes                                                                                                          |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------- |
 | `$userSettingsDirectory` | Where user-specific configuration/settings files are stored.                                                   |
-| [For Linux]              | On the command line, run `echo $XDG_CONFIG_HOME`                                                               |
+| [For Linux]              | On the command line, run `echo $XDG_CONFIG_HOME`  (by default, this is typically the `~/.config` directory)    |
 | [For Mac OSX]            | Check `/Users/(username)/Library/Preferences`                                                                  |
 | [For windows]            | This may be in the System Registry                                                                             |
 | `$eviRepo`               | The Evidence Repository value in the "settings" window                                                         |

--- a/src/components/tagging/tageditor.cpp
+++ b/src/components/tagging/tageditor.cpp
@@ -16,6 +16,7 @@ TagEditor::TagEditor(QWidget *parent) : QWidget(parent) {
 }
 
 TagEditor::~TagEditor() {
+  disconnect(getTagsReply, &QNetworkReply::finished, this, &TagEditor::onGetTagsComplete);
   delete couldNotCreateTagMsg;
   delete loading;
   delete tagCompleteTextBox;

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -219,7 +219,13 @@ void Settings::onSaveClicked() {
   inst.evidenceRepo = eviRepoTextBox->text();
   inst.accessKey = accessKeyTextBox->text();
   inst.secretKey = secretKeyTextBox->text();
+
+  QString originalApiUrl = inst.apiURL;
   inst.apiURL = hostPathTextBox->text();
+  if (originalApiUrl != hostPathTextBox->text()) {
+    NetMan::getInstance().refreshOperationsList();
+  }
+
   inst.screenshotExec = captureAreaCmdTextBox->text();
   inst.screenshotShortcutCombo = captureAreaShortcutTextBox->keySequence().toString();
   inst.captureWindowExec = captureWindowCmdTextBox->text();

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -104,11 +104,13 @@ TrayManager::~TrayManager() {
 }
 
 void TrayManager::cleanChooseOpSubmenu() {
+  // delete all of the existing events
   for (QAction* act : allOperationActions) {
     chooseOpSubmenu->removeAction(act);
     delete act;
   }
   allOperationActions.clear();
+  selectedAction = nullptr; // clear the selected action to ensure no funny business
 }
 
 void TrayManager::wireUi() {
@@ -310,6 +312,10 @@ void TrayManager::onOperationListUpdated(bool success,
       allOperationActions.push_back(newAction);
       chooseOpSubmenu->addAction(newAction);
     }
+    if (selectedAction == nullptr) {
+      AppSettings::getInstance().setOperationDetails("", "");
+    }
+
   }
   else {
     chooseOpStatusAction->setText(tr("Unable to load operations"));

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -90,7 +90,6 @@ TrayManager::~TrayManager() {
   cleanChooseOpSubmenu();  // must be done before deleting chooseOpSubmenu/action
 
   delete chooseOpStatusAction;
-  delete refreshOperationListAction;
   delete chooseOpSubmenu;
 
   delete trayIconMenu;
@@ -171,14 +170,7 @@ void TrayManager::createActions() {
   chooseOpStatusAction = new QAction("Loading operations...", chooseOpSubmenu);
   chooseOpStatusAction->setEnabled(false);
 
-  refreshOperationListAction = new QAction(tr("Refresh Operations"), chooseOpSubmenu);
-  connect(refreshOperationListAction, &QAction::triggered, [this] {
-    chooseOpStatusAction->setText("Loading operations...");
-    NetMan::getInstance().refreshOperationsList();
-  });
-
   chooseOpSubmenu->addAction(chooseOpStatusAction);
-  chooseOpSubmenu->addAction(refreshOperationListAction);
   chooseOpSubmenu->addSeparator();
 }
 
@@ -256,6 +248,10 @@ void TrayManager::createTrayMenu() {
 
   trayIcon = new QSystemTrayIcon(this);
   trayIcon->setContextMenu(trayIconMenu);
+  connect(trayIcon, &QSystemTrayIcon::activated, [this]{
+    chooseOpStatusAction->setText("Loading operations...");
+    NetMan::getInstance().refreshOperationsList();
+  });
 }
 
 void TrayManager::onScreenshotCaptured(const QString& path) {

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -74,7 +74,6 @@ class TrayManager : public QDialog {
   void cleanChooseOpSubmenu();
   QMenu *chooseOpSubmenu;
   QAction *chooseOpStatusAction;
-  QAction *refreshOperationListAction;
   QAction *selectedAction = nullptr;  // note: do not delete; for reference only
   std::vector<QAction *> allOperationActions;
 


### PR DESCRIPTION
This pull request  addresses an issue when switching servers. In particular, this addresses the situation where switching servers and changing operations could trigger a crash. While addressing this issue, some other quality of life changes were made to help users working on two different backends.

Note: This does not specifically enable support  for two backends, as there are still data integrity issues to consider, in addition to UI changes to support this model. Such work is outside of the scope of this minor bugfix-type pr.

Changes:
1. When switching hosts, the operations menu will be automatically refreshed.
2. If, after an operation refresh, your operation no longer exists, then you will move into a no-operation selected state, as if you freshly installed the application
3. The operation refresh button has been removed from the tray menu. Instead, whenever a user opens the tray menu, that list will refresh. Typically, we expect this to reload quickly enough that users will not see the loading operations message, but if they do, see it, the list should populate automatically once the data is loaded without the user having to open/close the tray menu 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
