### PR TITLE
Show local date time in evidence viewer

### DIFF
--- a/src/db/databaseconnection.cpp
+++ b/src/db/databaseconnection.cpp
@@ -70,6 +70,7 @@ model::Evidence DatabaseConnection::getEvidenceDetails(qint64 evidenceID) {
     rtn.uploadDate = query.value("upload_date").toDateTime();
 
     rtn.recordedDate.setTimeSpec(Qt::UTC);
+    rtn.uploadDate.setTimeSpec(Qt::UTC);
 
     auto getTagQuery = executeQuery(&db,
                                     "SELECT"
@@ -155,8 +156,8 @@ void DatabaseConnection::setEvidenceTags(const std::vector<model::Tag> &newTags,
 
 DBQuery DatabaseConnection::buildGetEvidenceWithFiltersQuery(const EvidenceFilters &filters) {
   QString query =
-      "SELECT id, path, operation_slug, content_type, description, error, recorded_date, "
-      "upload_date"
+      "SELECT"
+      " id, path, operation_slug, content_type, description, error, recorded_date, upload_date"
       " FROM evidence";
   std::vector<QVariant> values;
   std::vector<QString> parts;
@@ -215,6 +216,7 @@ std::vector<model::Evidence> DatabaseConnection::getEvidenceWithFilters(
     evi.uploadDate = resultSet.value("upload_date").toDateTime();
 
     evi.recordedDate.setTimeSpec(Qt::UTC);
+    evi.uploadDate.setTimeSpec(Qt::UTC);
 
     allEvidence.push_back(evi);
   }

--- a/src/db/databaseconnection.cpp
+++ b/src/db/databaseconnection.cpp
@@ -69,6 +69,8 @@ model::Evidence DatabaseConnection::getEvidenceDetails(qint64 evidenceID) {
     rtn.recordedDate = query.value("recorded_date").toDateTime();
     rtn.uploadDate = query.value("upload_date").toDateTime();
 
+    rtn.recordedDate.setTimeSpec(Qt::UTC);
+
     auto getTagQuery = executeQuery(&db,
                                     "SELECT"
                                     " id, tag_id, name"
@@ -211,6 +213,8 @@ std::vector<model::Evidence> DatabaseConnection::getEvidenceWithFilters(
     evi.errorText = resultSet.value("error").toString();
     evi.recordedDate = resultSet.value("recorded_date").toDateTime();
     evi.uploadDate = resultSet.value("upload_date").toDateTime();
+
+    evi.recordedDate.setTimeSpec(Qt::UTC);
 
     allEvidence.push_back(evi);
   }

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -346,7 +346,7 @@ void EvidenceManager::setRowText(int row, const model::Evidence& model) {
   setColText(COL_PATH, model.path);
   setColText(COL_ERROR_MSG, model.errorText);
 
-  auto uploadDateText = model.uploadDate.isNull() ? "Never" : model.uploadDate.toString(dateFormat);
+  auto uploadDateText = model.uploadDate.isNull() ? "Never" : model.uploadDate.toLocalTime().toString(dateFormat);
   setColText(COL_DATE_SUBMITTED, uploadDateText);
 }
 

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -332,12 +332,12 @@ EvidenceRow EvidenceManager::buildBaseEvidenceRow(qint64 evidenceID) {
 }
 
 void EvidenceManager::setRowText(int row, const model::Evidence& model) {
-  static QString dateFormat = "MMM dd, yyyy hh:mm";
+  static QString dateFormat = QLocale().dateTimeFormat(QLocale::ShortFormat);
 
   auto setColText = [this, row](int col, QString text) {
     evidenceTable->item(row, col)->setText(text);
   };
-  setColText(COL_DATE_CAPTURED, model.recordedDate.toString(dateFormat));
+  setColText(COL_DATE_CAPTURED, model.recordedDate.toLocalTime().toString(dateFormat));
   setColText(COL_DESCRIPTION, model.description);
   setColText(COL_OPERATION, model.operationSlug);
   setColText(COL_CONTENT_TYPE, model.contentType);


### PR DESCRIPTION
This PR corrects the time and date format shown in the evidence manager for the date created and date submitted columns. The time is now shown as local time (rather than UTC). Internally, time is still stored as UTC -- this is a presentation only fix. Additionally,  this PR also shows the date/time in local format. In the US, this will be `MM/DD/YY HH:MM am/pm` This format should match whatever the user has specified for their system, for better or worse.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
