### PR TITLE
correct minor memory leak in 3rd party library

### DIFF
--- a/src/helpers/multipartparser.cpp
+++ b/src/helpers/multipartparser.cpp
@@ -60,18 +60,18 @@ const std::string &MultipartParser::GenBodyContent() {
   }
 
   for (size_t i = 0; i < files_.size(); ++i) {
-    std::string *filename = new std::string();
-    std::string *content_type = new std::string();
+    std::string filename;
+    std::string content_type;
     std::string file_content = futures[i].get();
-    _get_file_name_type(files_[i].second, filename, content_type);
+    _get_file_name_type(files_[i].second, &filename, &content_type);
     body_content_ += "\r\n--";
     body_content_ += boundary_;
     body_content_ += "\r\nContent-Disposition: form-data; name=\"";
     body_content_ += files_[i].first;
     body_content_ += "\"; filename=\"";
-    body_content_ += *filename;
+    body_content_ += filename;
     body_content_ += "\"\r\nContent-Type: ";
-    body_content_ += *content_type;
+    body_content_ += content_type;
     body_content_ += "\r\n\r\n";
     body_content_ += file_content;
   }


### PR DESCRIPTION
This PR corrects a memory leak present in the multipart_parser library. 

As it so happens, the library made the same fix in early June, before we recognized the issue. That commit is here: https://github.com/AndsonYe/MultipartEncoder/commit/6e92871892657075f2399deeef60c1a63ac6b263

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
