### PR TITLE
Revise config file location for Linux and Windows

### DIFF
--- a/src/helpers/constants.h
+++ b/src/helpers/constants.h
@@ -9,7 +9,11 @@
 class Constants {
  public:
   static QString configLocation() {
+#ifdef Q_OS_MACOS
     return QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/config.json";
+#else
+    return QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/ashirt/config.json";
+#endif
   }
 
   static QString dbLocation() {


### PR DESCRIPTION
This PR adjusts the save location for the ashirt config file to live in `~/.config/ashirt/config.json` for linux and `%HOME%/AppData/local/ashirt/config.json` for windows (aka `%LOCALAPPDIR%/ashirt/config.json`). The config location for MacOS has not been changed.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.