### PR TITLE
require host path, access/secret keys populated before connection check

### DIFF
--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -253,6 +253,12 @@ void Settings::onBrowseClicked() {
 }
 
 void Settings::onTestConnectionClicked() {
+  if (hostPathTextBox->text().isEmpty()
+      || accessKeyTextBox->text().isEmpty()
+      || secretKeyTextBox->text().isEmpty()) {
+    connStatusLabel->setText("Please set Access Key, Secret key and Host Path first.");
+    return;
+  }
   testConnectionButton->startAnimation();
   testConnectionButton->setEnabled(false);
   currentTestReply = NetMan::getInstance().testConnection(


### PR DESCRIPTION
This PR locks out the test connection field if one (or more) of the fields is missing:
* Access Key
* Secret Key
* Host Path

This will correct Issue #50 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.