### PR TITLE
Allow multi-delete and table delete on evidence table

### DIFF
--- a/src/components/evidence_editor/evidenceeditor.h
+++ b/src/components/evidence_editor/evidenceeditor.h
@@ -37,7 +37,10 @@ class EvidenceEditor : public QWidget {
   model::Evidence encodeEvidence();
   void setEnabled(bool enable);
   SaveEvidenceResponse saveEvidence();
-  DeleteEvidenceResponse deleteEvidence();
+
+  /// deleteEvidence is a helper method to delete both the database record and
+  /// file location of the provided evidence IDs
+  std::vector<DeleteEvidenceResponse> deleteEvidence(std::vector<qint64> evidenceIDs);
 
  signals:
   void onWidgetReady();

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -301,7 +301,8 @@ void EvidenceManager::openTableContextMenu(QPoint pos) {
   }
   bool singleItemSelected = selectedRowCount == 1;
   copyPathToClipboardAction->setEnabled(singleItemSelected);
-  submitEvidenceAction->setEnabled(singleItemSelected );
+  bool wasSubmitted = !evidenceEditor->encodeEvidence().uploadDate.isNull();
+  submitEvidenceAction->setEnabled(singleItemSelected && !wasSubmitted);
 
   evidenceTableContextMenu->popup(evidenceTable->viewport()->mapToGlobal(pos));
 }

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -301,6 +301,7 @@ void EvidenceManager::openTableContextMenu(QPoint pos) {
   }
   bool singleItemSelected = selectedRowCount == 1;
   copyPathToClipboardAction->setEnabled(singleItemSelected);
+  submitEvidenceAction->setEnabled(singleItemSelected );
 
   evidenceTableContextMenu->popup(evidenceTable->viewport()->mapToGlobal(pos));
 }

--- a/src/forms/evidence/evidencemanager.h
+++ b/src/forms/evidence/evidencemanager.h
@@ -68,6 +68,8 @@ class EvidenceManager : public QDialog {
   void showEvent(QShowEvent* evt) override;
   /// selectedRowEvidenceID is a small helper to get the evidence id for the currently selected row.
   qint64 selectedRowEvidenceID();
+  /// selectedRowEvidenceIDs is a small helper to retrieve the id for all the selected rows
+  std::vector<qint64> selectedRowEvidenceIDs();
 
  signals:
   /**
@@ -84,6 +86,13 @@ class EvidenceManager : public QDialog {
   void deleteEvidenceTriggered();
   /// resetFilterButtonClicked recieves the reset filter button clicked event
   void resetFilterButtonClicked();
+  /// deleteAllTriggered recieves the triggered event from the delete table action
+  void deleteAllTriggered();
+  
+  /// deleteSet is a small helper to iterate through the provided list, delete the ids, and process
+  /// the result
+  void deleteSet(std::vector<qint64> ids);
+
   /// applyFilterForm updates the filter textbox to reflect the filter options chosen in the filter
   /// menu
   void applyFilterForm(const EvidenceFilters& filter);
@@ -113,6 +122,7 @@ class EvidenceManager : public QDialog {
   QAction* deleteEvidenceAction = nullptr;
   QAction* closeWindowAction = nullptr;
   QAction* copyPathToClipboardAction = nullptr;
+  QAction* deleteTableContentsAction = nullptr;
 
   // UI Elements
   QGridLayout* gridLayout = nullptr;


### PR DESCRIPTION
This PR provides two new abilities. 
First, it enables multi-select on the evidence table, either via a ctrl+click (or shift+click) or by dragging the mouse over multiple rows. When multiple items are selected AND the delete context menu is selected, all of the selected pieces of evidence will be removed. A warning prompt appears before deletion, and an error prompt appears after deletion, if some of the files could not be deleted.

Second, this PR adds the ability to remove all of the currently visible rows in the table, which effectively allows for deleting by whole groups of evidence based on a common condition -- e.g. belonging to a certain operation. Again, a prompt appears before, and conditionally after, in much the same was as a standard item delete.

Lastly, this will also remove directories if the last piece of evidence is removed from that directory. 

Note that the error condition for deletes has changed. Previously, a message would popup indicating exactly which file was not deleted. Now, we instead attempt to write a file with a list of all non-deleted files in that batch, and we will instead point the user to this file (if it is written)

Addresses Issues: #48, #49 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.