### PR TITLE
update test connection to evaluate response

### DIFF
--- a/ashirt.pro
+++ b/ashirt.pro
@@ -85,6 +85,7 @@ HEADERS += \
     src/components/tagging/tagview.h \
     src/components/tagging/tagwidget.h \
     src/db/databaseconnection.h \
+    src/dtos/checkConnection.h \
     src/exceptions/databaseerr.h \
     src/exceptions/fileerror.h \
     src/forms/evidence_filter/evidencefilter.h \

--- a/src/dtos/checkConnection.h
+++ b/src/dtos/checkConnection.h
@@ -10,7 +10,7 @@ class CheckConnection {
  public:
   CheckConnection(){}
 
-  bool ashirtConnected;
+  bool ok;
   bool parsedCorrectly;
 
   static CheckConnection parseJson(QByteArray data) {
@@ -20,10 +20,10 @@ class CheckConnection {
 
     cc.parsedCorrectly = false;
     if (err.error == QJsonParseError::NoError) {
-      QJsonValue val = doc["ashirtConnected"];
+      QJsonValue val = doc["ok"];
       if (!val.isUndefined()) {
         cc.parsedCorrectly = true;
-        cc.ashirtConnected = val.toBool();
+        cc.ok = val.toBool();
       }
     }
 

--- a/src/dtos/checkConnection.h
+++ b/src/dtos/checkConnection.h
@@ -1,0 +1,35 @@
+#ifndef TESTCONNECTION_H
+#define TESTCONNECTION_H
+
+#include <QVariant>
+
+#include "helpers/jsonhelpers.h"
+
+namespace dto {
+class CheckConnection {
+ public:
+  CheckConnection(){}
+
+  bool ashirtConnected;
+  bool parsedCorrectly;
+
+  static CheckConnection parseJson(QByteArray data) {
+    QJsonParseError err;
+    QJsonDocument doc = QJsonDocument::fromJson(data, &err);
+    CheckConnection cc;
+
+    cc.parsedCorrectly = false;
+    if (err.error == QJsonParseError::NoError) {
+      QJsonValue val = doc["ashirtConnected"];
+      if (!val.isUndefined()) {
+        cc.parsedCorrectly = true;
+        cc.ashirtConnected = val.toBool();
+      }
+    }
+
+    return cc;
+  }
+};
+}
+
+#endif // TESTCONNECTION_H

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -272,7 +272,7 @@ void Settings::onTestRequestComplete() {
     switch (statusCode) {
       case HttpStatus::StatusOK:
         connectionCheckResp = dto::CheckConnection::parseJson(currentTestReply->readAll());
-        if (connectionCheckResp.parsedCorrectly && connectionCheckResp.ashirtConnected) {
+        if (connectionCheckResp.parsedCorrectly && connectionCheckResp.ok) {
           connStatusLabel->setText("Connected");
         }
         else {

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -10,6 +10,7 @@
 
 #include "appconfig.h"
 #include "appsettings.h"
+#include "dtos/checkConnection.h"
 #include "helpers/http_status.h"
 #include "helpers/netman.h"
 #include "helpers/stopreply.h"
@@ -266,12 +267,20 @@ void Settings::onTestRequestComplete() {
       currentTestReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt(&ok);
 
   if (ok) {
+    dto::CheckConnection connectionCheckResp;
+
     switch (statusCode) {
       case HttpStatus::StatusOK:
-        connStatusLabel->setText("Connected");
+        connectionCheckResp = dto::CheckConnection::parseJson(currentTestReply->readAll());
+        if (connectionCheckResp.parsedCorrectly && connectionCheckResp.ashirtConnected) {
+          connStatusLabel->setText("Connected");
+        }
+        else {
+          connStatusLabel->setText("Unable to connect: Wrong or outdated server");
+        }
         break;
       case HttpStatus::StatusUnauthorized:
-        connStatusLabel->setText("Could not connect: Unauthorized (check api key and secret)");
+        connStatusLabel->setText("Could not connect: Unauthorized (check access key and secret)");
         break;
       case HttpStatus::StatusNotFound:
         connStatusLabel->setText("Could not connect: Not Found (check URL)");

--- a/src/helpers/netman.h
+++ b/src/helpers/netman.h
@@ -43,6 +43,7 @@ class NetMan : public QObject {
 
   void operationListUpdated(bool success,
                             std::vector<dto::Operation> operations = std::vector<dto::Operation>());
+  void testConnectionComplete(bool connected, int statusCode);
 
  private:
   QNetworkAccessManager *nam;
@@ -183,7 +184,7 @@ class NetMan : public QObject {
   }
 
   QNetworkReply *testConnection(QString host, QString apiKey, QString secretKey) {
-    return makeJsonRequest(METHOD_GET, "/api/operations", NO_BODY, host, apiKey, secretKey);
+    return makeJsonRequest(METHOD_GET, "/api/checkconnection", NO_BODY, host, apiKey, secretKey);
   }
 
   QNetworkReply *getAllOperations() { return makeJsonRequest(METHOD_GET, "/api/operations"); }


### PR DESCRIPTION
This PR revises the check connection code to evaluate the response from the server, in addition to the status code check. This will prevent the user from inadvertently connecting to an incorrect server.

Depends on PR [60 from ashirt-server](https://github.com/theparanoids/ashirt-server/pull/60)
Will likely conflict with PR #52, however either can be merged in either order, and conflicts can be corrected as needed.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.