### PR TITLE
Fixes to avoid runtime warnings

### DIFF
--- a/src/components/code_editor/codeeditor.cpp
+++ b/src/components/code_editor/codeeditor.cpp
@@ -58,6 +58,8 @@
 #include <QPainter>
 #include <QTextBlock>
 
+#include "helpers/constants.h"
+
 QColor currentLineHighlightColor = QColor(115, 191, 255);
 
 CodeEditor::CodeEditor(QWidget *parent) : QPlainTextEdit(parent) {
@@ -70,7 +72,7 @@ CodeEditor::CodeEditor(QWidget *parent) : QPlainTextEdit(parent) {
   // customize for text/code editing
   setLineWrapMode(LineWrapMode::NoWrap);
   setTabChangesFocus(false);
-  QFont font("source code pro");
+  QFont font(Constants::codeFont());
   font.setStyleHint(QFont::TypeWriter);
   setFont(font);
 

--- a/src/components/tagging/tageditor.cpp
+++ b/src/components/tagging/tageditor.cpp
@@ -16,7 +16,9 @@ TagEditor::TagEditor(QWidget *parent) : QWidget(parent) {
 }
 
 TagEditor::~TagEditor() {
-  disconnect(getTagsReply, &QNetworkReply::finished, this, &TagEditor::onGetTagsComplete);
+  if (getTagsReply != nullptr ) {
+    disconnect(getTagsReply, &QNetworkReply::finished, this, &TagEditor::onGetTagsComplete);
+  }
   delete couldNotCreateTagMsg;
   delete loading;
   delete tagCompleteTextBox;

--- a/src/components/tagging/tagwidget.cpp
+++ b/src/components/tagging/tagwidget.cpp
@@ -39,6 +39,8 @@ void TagWidget::buildTag() {
   QFont labelFont;
 #ifdef Q_OS_MACOS
   labelFont = QFont("Arial", 14);
+#elif defined(Q_OS_LINUX)
+  labelFont = QFont("Liberation Sans", 12);
 #else
   labelFont = QFont("Sans", 12);
 #endif

--- a/src/components/tagging/tagwidget.cpp
+++ b/src/components/tagging/tagwidget.cpp
@@ -38,7 +38,7 @@ void TagWidget::mouseReleaseEvent(QMouseEvent* evt) {
 void TagWidget::buildTag() {
   QFont labelFont;
 #ifdef Q_OS_MACOS
-  labelFont = QFont("Sans", 14);
+  labelFont = QFont("Arial", 14);
 #else
   labelFont = QFont("Sans", 12);
 #endif

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -35,7 +35,6 @@ enum ColumnIndexes {
 static QStringList columnNames() {
   static QStringList names;
   if (names.count() == 0) {
-    names.insert(COL_ERROR_MSG, "Error");
     names.insert(COL_DATE_CAPTURED, "Date Captured");
     names.insert(COL_OPERATION, "Operation");
     names.insert(COL_PATH, "Path");
@@ -44,6 +43,7 @@ static QStringList columnNames() {
     names.insert(COL_SUBMITTED, "Submitted");
     names.insert(COL_DATE_SUBMITTED, "Date Submitted");
     names.insert(COL_FAILED, "Failed");
+    names.insert(COL_ERROR_MSG, "Error");
   }
   return names;
 }

--- a/src/helpers/constants.h
+++ b/src/helpers/constants.h
@@ -69,6 +69,14 @@ class Constants {
     return "https://github.com/theparanoids/ashirt/releases";
   }
 
+  static QString codeFont() {
+    #ifdef Q_OS_MACX
+    return "monaco";
+    #endif
+
+    return "source code pro";
+  }
+
  private:
   enum RepoField {
     owner = 0,

--- a/src/helpers/netman.h
+++ b/src/helpers/netman.h
@@ -214,8 +214,10 @@ class NetMan : public QObject {
   /// refreshOperationsList retrieves the operations currently visible to the user. Results should be
   /// retrieved by listening for the operationListUpdated signal
   void refreshOperationsList() {
-    allOpsReply = getAllOperations();
-    connect(allOpsReply, &QNetworkReply::finished, this, &NetMan::onGetOpsComplete);
+    if (allOpsReply == nullptr) {
+      allOpsReply = getAllOperations();
+      connect(allOpsReply, &QNetworkReply::finished, this, &NetMan::onGetOpsComplete);
+    }
   }
 
   /// getOperationTags retrieves the tags for specified operation from the ASHIRT API server

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -152,11 +152,17 @@ void TrayManager::closeEvent(QCloseEvent* event) {
 }
 
 void TrayManager::createActions() {
+  auto toTop = [](QDialog* window) {
+    window->show(); // display the window
+    window->raise(); // bring to the top (mac)
+    window->activateWindow(); // alternate bring to the top (windows)
+  };
+
   quitAction = new QAction(tr("Quit"), this);
   connect(quitAction, &QAction::triggered, qApp, &QCoreApplication::quit);
 
   showSettingsAction = new QAction(tr("Settings"), this);
-  connect(showSettingsAction, &QAction::triggered, settingsWindow, &QWidget::show);
+  connect(showSettingsAction, &QAction::triggered, [this, toTop](){toTop(settingsWindow);});
 
   currentOperationMenuAction = new QAction(this);
   currentOperationMenuAction->setEnabled(false);
@@ -168,10 +174,10 @@ void TrayManager::createActions() {
   connect(captureWindowAction, &QAction::triggered, this, &TrayManager::captureWindowActionTriggered);
 
   showEvidenceManagerAction = new QAction(tr("View Accumulated Evidence"), this);
-  connect(showEvidenceManagerAction, &QAction::triggered, evidenceManagerWindow, &QWidget::show);
+  connect(showEvidenceManagerAction, &QAction::triggered, [this, toTop](){toTop(evidenceManagerWindow);});
 
   showCreditsAction = new QAction(tr("About"), this);
-  connect(showCreditsAction, &QAction::triggered, creditsWindow, &QWidget::show);
+  connect(showCreditsAction, &QAction::triggered, [this, toTop](){toTop(creditsWindow);});
 
   addCodeblockAction = new QAction(tr("Add Codeblock from Clipboard"), this);
   connect(addCodeblockAction, &QAction::triggered, this, &TrayManager::captureCodeblockActionTriggered);


### PR DESCRIPTION
This PR corrects a number of minor issues that represent themselves as runtime warnings when running ashirt via qt creator / in non-release mode. The errors themselves seem to be minor.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.