### PR TITLE
Also save codeblock content when saving/submitting evidence

### DIFF
--- a/src/components/code_editor/codeblockview.cpp
+++ b/src/components/code_editor/codeblockview.cpp
@@ -75,6 +75,7 @@ void CodeBlockView::loadFromFile(QString filepath) {
 void CodeBlockView::saveEvidence() {
   loadedCodeblock.source = sourceTextBox->text();
   loadedCodeblock.subtype = languageComboBox->currentData().toString();
+  loadedCodeblock.content = codeEditor->toPlainText();
   if (loadedCodeblock.filePath() != "") {
     try {
       Codeblock::saveCodeblock(loadedCodeblock);


### PR DESCRIPTION
This PR saves the content of a codeblock prior to submitting the codeblock. 

Addresses Issue #60

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.