### PR TITLE
Restructure Tray Manager to match the general structure used by other classes

### DIFF
--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -56,21 +56,10 @@ TrayManager::TrayManager(DatabaseConnection* db) {
   screenshotTool = new Screenshot();
   hotkeyManager = new HotkeyManager();
   hotkeyManager->updateHotkeys();
-
-  buildUi();
-
-  setActiveOperationLabel();
   updateCheckTimer = new QTimer(this);
   updateCheckTimer->start(24*60*60*1000); // every day
 
-  QIcon icon = QIcon(ICON);
-  // TODO: figure out if any other environments support masking
-#ifdef Q_OS_MACOS
-  icon.setIsMask(true);
-#endif
-
-  trayIcon->setIcon(icon);
-  trayIcon->show();
+  buildUi();
   wireUi();
 
   // delayed so that windows can listen for get all ops signal
@@ -140,8 +129,18 @@ void TrayManager::buildUi() {
   chooseOpSubmenu->addAction(chooseOpStatusAction);
   chooseOpSubmenu->addSeparator();
 
+  setActiveOperationLabel();
+
+  QIcon icon = QIcon(ICON);
+  // TODO: figure out if any other environments support masking
+#ifdef Q_OS_MACOS
+  icon.setIsMask(true);
+#endif
+
   trayIcon = new QSystemTrayIcon(this);
   trayIcon->setContextMenu(trayIconMenu);
+  trayIcon->setIcon(icon);
+  trayIcon->show();
 }
 
 void TrayManager::wireUi() {

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -150,22 +150,20 @@ void TrayManager::wireUi() {
     window->raise(); // bring to the top (mac)
     window->activateWindow(); // alternate bring to the top (windows)
   };
-  connect(quitAction, &QAction::triggered, qApp, &QCoreApplication::quit);
-  connect(showSettingsAction, &QAction::triggered, [this, toTop](){toTop(settingsWindow);});
-  connect(captureScreenAreaAction, &QAction::triggered, this, &TrayManager::captureAreaActionTriggered);
-  connect(captureWindowAction, &QAction::triggered, this, &TrayManager::captureWindowActionTriggered);
-  connect(showEvidenceManagerAction, &QAction::triggered, [this, toTop](){toTop(evidenceManagerWindow);});
-  connect(showCreditsAction, &QAction::triggered, [this, toTop](){toTop(creditsWindow);});
-  connect(addCodeblockAction, &QAction::triggered, this, &TrayManager::captureCodeblockActionTriggered);
-
-  connect(trayIcon, &QSystemTrayIcon::activated, [this]{
-    chooseOpStatusAction->setText("Loading operations...");
-    NetMan::getInstance().refreshOperationsList();
-  });
+  auto actTriggered = &QAction::triggered;
+  // connect actions
+  connect(quitAction, actTriggered, qApp, &QCoreApplication::quit);
+  connect(showSettingsAction, actTriggered, [this, toTop](){toTop(settingsWindow);});
+  connect(captureScreenAreaAction, actTriggered, this, &TrayManager::captureAreaActionTriggered);
+  connect(captureWindowAction, actTriggered, this, &TrayManager::captureWindowActionTriggered);
+  connect(showEvidenceManagerAction, actTriggered, [this, toTop](){toTop(evidenceManagerWindow);});
+  connect(showCreditsAction, actTriggered, [this, toTop](){toTop(creditsWindow);});
+  connect(addCodeblockAction, actTriggered, this, &TrayManager::captureCodeblockActionTriggered);
 
   connect(screenshotTool, &Screenshot::onScreenshotCaptured, this,
           &TrayManager::onScreenshotCaptured);
 
+  // connect to hotkey signals
   connect(hotkeyManager, &HotkeyManager::codeblockHotkeyPressed, this,
           &TrayManager::captureCodeblockActionTriggered);
   connect(hotkeyManager, &HotkeyManager::captureAreaHotkeyPressed, this,
@@ -173,12 +171,19 @@ void TrayManager::wireUi() {
   connect(hotkeyManager, &HotkeyManager::captureWindowHotkeyPressed, this,
           &TrayManager::captureWindowActionTriggered);
 
+  // connect to network signals
   connect(&NetMan::getInstance(), &NetMan::operationListUpdated, this,
           &TrayManager::onOperationListUpdated);
   connect(&NetMan::getInstance(), &NetMan::releasesChecked, this, &TrayManager::onReleaseCheck);
   connect(&AppSettings::getInstance(), &AppSettings::onOperationUpdated, this,
           &TrayManager::setActiveOperationLabel);
+  
   connect(trayIcon, &QSystemTrayIcon::messageClicked, [](){QDesktopServices::openUrl(Constants::releasePageUrl());});
+  connect(trayIcon, &QSystemTrayIcon::activated, [this] {
+    chooseOpStatusAction->setText("Loading operations...");
+    NetMan::getInstance().refreshOperationsList();
+  });
+
   connect(updateCheckTimer, &QTimer::timeout, this, &TrayManager::checkForUpdate);
 }
 

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -57,24 +57,20 @@ TrayManager::TrayManager(DatabaseConnection* db) {
   hotkeyManager = new HotkeyManager();
   hotkeyManager->updateHotkeys();
 
-  settingsWindow = new Settings(hotkeyManager, this);
-  evidenceManagerWindow = new EvidenceManager(db, this);
-  creditsWindow = new Credits(this);
+  buildUi();
 
-  createActions();
-  createTrayMenu();
+  setActiveOperationLabel();
+  updateCheckTimer = new QTimer(this);
+  updateCheckTimer->start(24*60*60*1000); // every day
+
   QIcon icon = QIcon(ICON);
   // TODO: figure out if any other environments support masking
 #ifdef Q_OS_MACOS
   icon.setIsMask(true);
 #endif
+
   trayIcon->setIcon(icon);
-
-  setActiveOperationLabel();
   trayIcon->show();
-  updateCheckTimer = new QTimer(this);
-  updateCheckTimer->start(24*60*60*1000); // every day
-
   wireUi();
 
   // delayed so that windows can listen for get all ops signal
@@ -109,17 +105,64 @@ TrayManager::~TrayManager() {
   delete creditsWindow;
 }
 
-void TrayManager::cleanChooseOpSubmenu() {
-  // delete all of the existing events
-  for (QAction* act : allOperationActions) {
-    chooseOpSubmenu->removeAction(act);
-    delete act;
-  }
-  allOperationActions.clear();
-  selectedAction = nullptr; // clear the selected action to ensure no funny business
+void TrayManager::buildUi() {
+  // create subwindows
+  settingsWindow = new Settings(hotkeyManager, this);
+  evidenceManagerWindow = new EvidenceManager(db, this);
+  creditsWindow = new Credits(this);
+
+  trayIconMenu = new QMenu(this);
+  chooseOpSubmenu = new QMenu(tr("Select Operation"));
+
+  // small helper to create an action and assign it to the tray
+  auto addToTray = [this](QString text, QAction** act){
+    *act = new QAction(text, this);
+    trayIconMenu->addAction(*act);
+  };
+
+  // Tray Ordering
+  addToTray(tr("Add Codeblock from Clipboard"), &addCodeblockAction);
+  addToTray(tr("Capture Screen Area"), &captureScreenAreaAction);
+  addToTray(tr("Capture Window"), &captureWindowAction);
+  addToTray(tr("View Accumulated Evidence"), &showEvidenceManagerAction);
+  addToTray(tr("Settings"), &showSettingsAction);
+  trayIconMenu->addSeparator();
+  addToTray(tr(""), &currentOperationMenuAction);
+  trayIconMenu->addMenu(chooseOpSubmenu);
+  trayIconMenu->addSeparator();
+  addToTray(tr("About"), &showCreditsAction);
+  addToTray(tr("Quit"), &quitAction);
+
+  // finish action config
+  currentOperationMenuAction->setEnabled(false);
+  chooseOpStatusAction = new QAction("Loading operations...", chooseOpSubmenu);
+  chooseOpStatusAction->setEnabled(false);
+  chooseOpSubmenu->addAction(chooseOpStatusAction);
+  chooseOpSubmenu->addSeparator();
+
+  trayIcon = new QSystemTrayIcon(this);
+  trayIcon->setContextMenu(trayIconMenu);
 }
 
 void TrayManager::wireUi() {
+  auto toTop = [](QDialog* window) {
+    window->show(); // display the window
+    window->raise(); // bring to the top (mac)
+    window->activateWindow(); // alternate bring to the top (windows)
+  };
+  connect(quitAction, &QAction::triggered, qApp, &QCoreApplication::quit);
+  connect(showSettingsAction, &QAction::triggered, [this, toTop](){toTop(settingsWindow);});
+  connect(captureScreenAreaAction, &QAction::triggered, this, &TrayManager::captureAreaActionTriggered);
+  connect(captureWindowAction, &QAction::triggered, this, &TrayManager::captureWindowActionTriggered);
+  connect(showEvidenceManagerAction, &QAction::triggered, [this, toTop](){toTop(evidenceManagerWindow);});
+  connect(showCreditsAction, &QAction::triggered, [this, toTop](){toTop(creditsWindow);});
+  connect(addCodeblockAction, &QAction::triggered, this, &TrayManager::captureCodeblockActionTriggered);
+
+  connect(trayIcon, &QSystemTrayIcon::activated, [this]{
+    chooseOpStatusAction->setText("Loading operations...");
+    NetMan::getInstance().refreshOperationsList();
+  });
+
   connect(screenshotTool, &Screenshot::onScreenshotCaptured, this,
           &TrayManager::onScreenshotCaptured);
 
@@ -139,6 +182,16 @@ void TrayManager::wireUi() {
   connect(updateCheckTimer, &QTimer::timeout, this, &TrayManager::checkForUpdate);
 }
 
+void TrayManager::cleanChooseOpSubmenu() {
+  // delete all of the existing events
+  for (QAction* act : allOperationActions) {
+    chooseOpSubmenu->removeAction(act);
+    delete act;
+  }
+  allOperationActions.clear();
+  selectedAction = nullptr; // clear the selected action to ensure no funny business
+}
+
 void TrayManager::closeEvent(QCloseEvent* event) {
 #ifdef Q_OS_MACOS
   if (!event->spontaneous() || !isVisible()) {
@@ -149,45 +202,6 @@ void TrayManager::closeEvent(QCloseEvent* event) {
     hide();
     event->ignore();
   }
-}
-
-void TrayManager::createActions() {
-  auto toTop = [](QDialog* window) {
-    window->show(); // display the window
-    window->raise(); // bring to the top (mac)
-    window->activateWindow(); // alternate bring to the top (windows)
-  };
-
-  quitAction = new QAction(tr("Quit"), this);
-  connect(quitAction, &QAction::triggered, qApp, &QCoreApplication::quit);
-
-  showSettingsAction = new QAction(tr("Settings"), this);
-  connect(showSettingsAction, &QAction::triggered, [this, toTop](){toTop(settingsWindow);});
-
-  currentOperationMenuAction = new QAction(this);
-  currentOperationMenuAction->setEnabled(false);
-
-  captureScreenAreaAction = new QAction(tr("Capture Screen Area"), this);
-  connect(captureScreenAreaAction, &QAction::triggered, this, &TrayManager::captureAreaActionTriggered);
-
-  captureWindowAction = new QAction(tr("Capture Window"), this);
-  connect(captureWindowAction, &QAction::triggered, this, &TrayManager::captureWindowActionTriggered);
-
-  showEvidenceManagerAction = new QAction(tr("View Accumulated Evidence"), this);
-  connect(showEvidenceManagerAction, &QAction::triggered, [this, toTop](){toTop(evidenceManagerWindow);});
-
-  showCreditsAction = new QAction(tr("About"), this);
-  connect(showCreditsAction, &QAction::triggered, [this, toTop](){toTop(creditsWindow);});
-
-  addCodeblockAction = new QAction(tr("Add Codeblock from Clipboard"), this);
-  connect(addCodeblockAction, &QAction::triggered, this, &TrayManager::captureCodeblockActionTriggered);
-
-  chooseOpSubmenu = new QMenu(tr("Select Operation"));
-  chooseOpStatusAction = new QAction("Loading operations...", chooseOpSubmenu);
-  chooseOpStatusAction->setEnabled(false);
-
-  chooseOpSubmenu->addAction(chooseOpStatusAction);
-  chooseOpSubmenu->addSeparator();
 }
 
 void TrayManager::spawnGetInfoWindow(qint64 evidenceID) {
@@ -245,29 +259,6 @@ void TrayManager::onCodeblockCapture() {
       std::cout << "could not write to the database: " << e.text().toStdString() << std::endl;
     }
   }
-}
-
-void TrayManager::createTrayMenu() {
-  trayIconMenu = new QMenu(this);
-
-  trayIconMenu->addAction(this->addCodeblockAction);
-  trayIconMenu->addAction(this->captureScreenAreaAction);
-  trayIconMenu->addAction(this->captureWindowAction);
-  trayIconMenu->addAction(this->showEvidenceManagerAction);
-  trayIconMenu->addAction(this->showSettingsAction);
-  trayIconMenu->addSeparator();
-  trayIconMenu->addAction(this->currentOperationMenuAction);
-  trayIconMenu->addMenu(chooseOpSubmenu);
-  trayIconMenu->addSeparator();
-  trayIconMenu->addAction(this->showCreditsAction);
-  trayIconMenu->addAction(this->quitAction);
-
-  trayIcon = new QSystemTrayIcon(this);
-  trayIcon->setContextMenu(trayIconMenu);
-  connect(trayIcon, &QSystemTrayIcon::activated, [this]{
-    chooseOpStatusAction->setText("Loading operations...");
-    NetMan::getInstance().refreshOperationsList();
-  });
 }
 
 void TrayManager::onScreenshotCaptured(const QString& path) {

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -41,8 +41,19 @@ class TrayManager : public QDialog {
   TrayManager(DatabaseConnection *);
   ~TrayManager();
 
- protected:
-  void closeEvent(QCloseEvent *event) override;
+ private:
+  void wireUi();
+  void createActions();
+  void createTrayMenu();
+  qint64 createNewEvidence(QString filepath, QString evidenceType);
+  void spawnGetInfoWindow(qint64 evidenceID);
+  void showNoOperationSetTrayMessage();
+  void checkForUpdate();
+  void cleanChooseOpSubmenu();
+
+ private slots:
+  void onOperationListUpdated(bool success, const std::vector<dto::Operation> &operations);
+  void onReleaseCheck(bool success, std::vector<dto::GithubRelease> releases);
 
  public slots:
   void onScreenshotCaptured(const QString &filepath);
@@ -52,20 +63,24 @@ class TrayManager : public QDialog {
   void captureWindowActionTriggered();
   void captureCodeblockActionTriggered();
 
- private slots:
-  void onOperationListUpdated(bool success, const std::vector<dto::Operation> &operations);
-  void onReleaseCheck(bool success, std::vector<dto::GithubRelease> releases);
+ protected:
+  void closeEvent(QCloseEvent *event) override;
 
  private:
-  void createActions();
-  void createTrayMenu();
-  void wireUi();
-  qint64 createNewEvidence(QString filepath, QString evidenceType);
-  void spawnGetInfoWindow(qint64 evidenceID);
-  void showNoOperationSetTrayMessage();
-  void checkForUpdate();
+  DatabaseConnection *db = nullptr;
+  HotkeyManager *hotkeyManager = nullptr;
+  Screenshot *screenshotTool = nullptr;
+  QTimer *updateCheckTimer = nullptr;
 
- private:
+  // Subwindows
+  Settings *settingsWindow = nullptr;
+  EvidenceManager *evidenceManagerWindow = nullptr;
+  Credits *creditsWindow = nullptr;
+
+  // UI Elements
+  QSystemTrayIcon *trayIcon = nullptr;
+  QMenu *trayIconMenu = nullptr;
+
   QAction *quitAction = nullptr;
   QAction *showSettingsAction = nullptr;
   QAction *currentOperationMenuAction = nullptr;
@@ -75,24 +90,10 @@ class TrayManager : public QDialog {
   QAction *showCreditsAction = nullptr;
   QAction *addCodeblockAction = nullptr;
 
-  void cleanChooseOpSubmenu();
   QMenu *chooseOpSubmenu = nullptr;
   QAction *chooseOpStatusAction = nullptr;
   QAction *selectedAction = nullptr;  // note: do not delete; for reference only
   std::vector<QAction *> allOperationActions;
-
-  QSystemTrayIcon *trayIcon = nullptr;
-  QMenu *trayIconMenu = nullptr;
-
-  Settings *settingsWindow = nullptr;
-  EvidenceManager *evidenceManagerWindow = nullptr;
-  Credits *creditsWindow = nullptr;
-
-  Screenshot *screenshotTool = nullptr;
-  HotkeyManager *hotkeyManager = nullptr;
-
-  DatabaseConnection *db = nullptr;
-  QTimer *updateCheckTimer = nullptr;
 };
 
 #endif  // QT_NO_SYSTEMTRAYICON

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -66,32 +66,32 @@ class TrayManager : public QDialog {
   void checkForUpdate();
 
  private:
-  QAction *quitAction;
-  QAction *showSettingsAction;
-  QAction *currentOperationMenuAction;
-  QAction *captureScreenAreaAction;
-  QAction *captureWindowAction;
-  QAction *showEvidenceManagerAction;
-  QAction *showCreditsAction;
-  QAction *addCodeblockAction;
+  QAction *quitAction = nullptr;
+  QAction *showSettingsAction = nullptr;
+  QAction *currentOperationMenuAction = nullptr;
+  QAction *captureScreenAreaAction = nullptr;
+  QAction *captureWindowAction = nullptr;
+  QAction *showEvidenceManagerAction = nullptr;
+  QAction *showCreditsAction = nullptr;
+  QAction *addCodeblockAction = nullptr;
 
   void cleanChooseOpSubmenu();
-  QMenu *chooseOpSubmenu;
-  QAction *chooseOpStatusAction;
+  QMenu *chooseOpSubmenu = nullptr;
+  QAction *chooseOpStatusAction = nullptr;
   QAction *selectedAction = nullptr;  // note: do not delete; for reference only
   std::vector<QAction *> allOperationActions;
 
-  QSystemTrayIcon *trayIcon;
-  QMenu *trayIconMenu;
+  QSystemTrayIcon *trayIcon = nullptr;
+  QMenu *trayIconMenu = nullptr;
 
-  Settings *settingsWindow;
-  EvidenceManager *evidenceManagerWindow;
-  Credits *creditsWindow;
+  Settings *settingsWindow = nullptr;
+  EvidenceManager *evidenceManagerWindow = nullptr;
+  Credits *creditsWindow = nullptr;
 
-  Screenshot *screenshotTool;
-  HotkeyManager *hotkeyManager;
+  Screenshot *screenshotTool = nullptr;
+  HotkeyManager *hotkeyManager = nullptr;
 
-  DatabaseConnection *db;
+  DatabaseConnection *db = nullptr;
   QTimer *updateCheckTimer = nullptr;
 };
 

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -42,9 +42,8 @@ class TrayManager : public QDialog {
   ~TrayManager();
 
  private:
+  void buildUi();
   void wireUi();
-  void createActions();
-  void createTrayMenu();
   qint64 createNewEvidence(QString filepath, QString evidenceType);
   void spawnGetInfoWindow(qint64 evidenceID);
   void showNoOperationSetTrayMessage();


### PR DESCRIPTION
This PR refactors traymanager slightly to be organized similar to other UI classes. Functionally, nothing should be different.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.