### PR TITLE
Allow migration of data between computers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,30 @@ When trying to apply both a "before" date and "after" date filter, the system wi
 
 When applying only one date, the range is unbounded on the other end. That is, dates are implicitly "from the start of time" to "until the end of time"
 
+## Migrating Data
+
+All data collected from the ASHIRT application can be exported, and then re-imported, into a new ASHIRT instance. Doing so creates a _copy_ on the new system, and the user can pick up where they left off. It is currently recommended that this be used only for moving (rather than copying) data from one computer to the other, when the latter will _replace_ the former. For sharing content, it is recommended that the Web UI be used instead.
+
+To begin an export, open the tray menu, and select Edit > Export. This will open a window where the user can choose a destination, and opt to export only configuration details (specifically, the server connection details), only the accumulated evidence, or both. Finally, press the "Export" button. This will kick off a process that gathers this data, and starts moving it into a central directory for easy migration.
+
+To import content, open the tray and select Edit > Import. This will open a similar dialog to export, but for importing content. Navigate to the export directory, and select the `system.json` file, and then press the "Import" button. This will kick off a process to bring the exported data into the new system.
+
+Once an import or export has been started, you can close the window. A tray message will display once the action completes. To get progress updates, you can simply reopen the import/export menu. Progress will update once the total number of files is known, and for each file copied.
+
+### Caveats
+
+There are a handful of points to be aware of when importing and exporting.
+
+1. **You can only export ALL content or NO content** Individual asset selection is currently not supported.
+2. **Imports and Exports cannot be cancelled once started**
+3. **Creating or editing evidence while importing may be slower**  The underlying database only allows a single write connection, which means that the import process and main process that allows writing to the local database will need to take turns writing. Depending on your usecase and system, this may or may not delay concurrent work.
+4. **Importing while Exporing (or vice versa) may be confusing** Import and export actions are done as a point-in-time action. This means that export will only export what is known to it at the time the "Export" button is pressed. This remains true for import as well, though is less relevant for concurrent actions. As a general peice of guidance, import and export should not be done simultaneously.
+5. **Imports can be re-run, though this is of questionable value** Currently there is no way to know if an import has been previously run. Re-importing _evidence_ will cause duplicated files and database records. This does not hamper the system, but is difficult (and manual) to clean up. Please be sure that content has not been previously imported before pressing the import button.
+6. **Exports are unprotected and easily sharable** For better or worse, when creating an export file, know that anyone can read or copy this data. Encrypting or decrypting is left as an exercise to the user, should they wish to do so.
+7. **Limitations** Currently, the following limitations exist for importing and exporting data:
+   1. "Settings" are not transfered -- specifically, last used tags and operation
+   2. Things that could be operating system dependent are not transfers. This is most of the configuration: hotkey bindings, screenshot commands, and the evidence directory
+
 ## Local Files
 
 You should never need to access these files outside of the application, however, for clarity, the following files are generate and maintained by this application:

--- a/Readme_Developer.md
+++ b/Readme_Developer.md
@@ -76,3 +76,11 @@ To apply code formatting (Linux/Bash), run `find src/ -iname "*.cpp" -o -iname "
 2. No CLI for non-qt/non-tray OSes
 3. Remove dock icon on mac?
    1. Possibly useful: https://github.com/keepassxreboot/keepassxc/commit/45344bb2acea61806d5e7f5f9eadfa779ca536ae#diff-a9e708931297992b08350ff7122fcb91R157
+
+## Recommendations for tasks
+
+1. Imports are not versioned or identifiable.
+   1. Identification can be accomplished by adding a uuid to the system.json export, and having a table that keeps track of which imported uuids have been used
+   2. Simple, perhaps ineffectual, versioning could be accomplished by using the ID above, and adding a column to the evidence table, indicating which export batch was associated with that evidence. The export `evidence.json` would then need to add this identification to each entry where this value was known.
+   3. An alternative for identification could be to hash (e.g. md5) each file and provide that has in `evidence.json`. A similar hash would need to exist on each piece of evidence in the database. The system could then use that hash, in combination with other data, to determine if this evidence has been previously imported.
+   4. A third alternative would be to go by the server's evidenceID or slug, if available (this is currently not tracked locally). A separate mechanism would be needed for non-submitted evidence.

--- a/ashirt.pro
+++ b/ashirt.pro
@@ -108,6 +108,7 @@ HEADERS += \
     src/helpers/clipboard/clipboardhelper.h \
     src/helpers/constants.h \
     src/helpers/request_builder.h \
+    src/helpers/system_helpers.h \
     src/helpers/ui_helpers.h \
     src/models/codeblock.h \
     src/helpers/file_helpers.h \

--- a/ashirt.pro
+++ b/ashirt.pro
@@ -69,6 +69,7 @@ SOURCES += \
     src/helpers/multipartparser.cpp \
     src/hotkeymanager.cpp \
     src/main.cpp \
+    src/porting/system_manifest.cpp \
     src/traymanager.cpp \
     src/helpers/screenshot.cpp \
     src/helpers/stopreply.cpp \

--- a/ashirt.pro
+++ b/ashirt.pro
@@ -64,6 +64,7 @@ SOURCES += \
     src/forms/evidence_filter/evidencefilter.cpp \
     src/forms/evidence_filter/evidencefilterform.cpp \
     src/forms/getinfo/getinfo.cpp \
+    src/forms/porting/porting_dialog.cpp \
     src/helpers/clipboard/clipboardhelper.cpp \
     src/models/codeblock.cpp \
     src/helpers/multipartparser.cpp \
@@ -106,6 +107,7 @@ HEADERS += \
     src/forms/evidence_filter/evidencefilter.h \
     src/forms/evidence_filter/evidencefilterform.h \
     src/forms/getinfo/getinfo.h \
+    src/forms/porting/porting_dialog.h \
     src/helpers/clipboard/clipboardhelper.h \
     src/helpers/constants.h \
     src/helpers/request_builder.h \

--- a/ashirt.pro
+++ b/ashirt.pro
@@ -116,6 +116,9 @@ HEADERS += \
     src/hotkeymanager.h \
     src/models/evidence.h \
     src/models/tag.h \
+    src/porting/evidence_manifest.h \
+    src/porting/system_manifest.h \
+    src/porting/system_porting_options.h \
     src/traymanager.h \
     src/appconfig.h \
     src/appsettings.h \

--- a/ashirt.pro
+++ b/ashirt.pro
@@ -97,6 +97,7 @@ HEADERS += \
     src/components/tagging/tagview.h \
     src/components/tagging/tagwidget.h \
     src/db/databaseconnection.h \
+    src/db/query_result.h \
     src/dtos/github_release.h \
     src/dtos/checkConnection.h \
     src/exceptions/databaseerr.h \

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -53,6 +53,9 @@ class AppConfig {
     }
   }
 
+  /// readConfig attempts to read the provided path and parse the configuration file.
+  /// If successful, the config file is loaded. If the config file is missing, then a
+  /// default file will be generated. If some other error occurs, a FileError is thrown.
   void readConfig(QString location=Constants::configLocation()) {
     QFile configFile(location);
     if (!configFile.open(QIODevice::ReadOnly)) {
@@ -84,6 +87,8 @@ class AppConfig {
     }
   }
 
+  /// writeDefaultConfig attempts to write a basic configuration to disk.
+  /// This is useful on first runs/when no config data is set.
   void writeDefaultConfig() {
     evidenceRepo = Constants::defaultEvidenceRepo();
 
@@ -102,6 +107,7 @@ class AppConfig {
 
  public:
 
+  /// applyConfig takes a parsed json configuration, and applies it to the current running app instance
   void applyConfig(QJsonObject src) {
     std::vector<std::pair<QString, QString*>> fields = {
         std::pair<QString, QString*>("evidenceRepo", &evidenceRepo),
@@ -123,6 +129,7 @@ class AppConfig {
     }
   }
 
+  /// serializeConfig creates a Json Object from the currently-used configuration
   QJsonObject serializeConfig() {
     QJsonObject root;
     root["evidenceRepo"] = evidenceRepo;
@@ -137,6 +144,8 @@ class AppConfig {
     return root;
   }
 
+  /// writeConfig serializes the running config, and writes the assoicated file to the given path.
+  /// The path defaults to Constants::configLocation()
   void writeConfig(QString alternateSavePath="") {
     QString writeLoc = alternateSavePath == "" ? Constants::configLocation() : alternateSavePath;
 

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -6,6 +6,7 @@
 
 #include <QDir>
 #include <QFile>
+#include <QJsonValue>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QStandardPaths>
@@ -15,6 +16,8 @@
 
 #include "exceptions/fileerror.h"
 #include "helpers/constants.h"
+#include "helpers/file_helpers.h"
+#include "helpers/jsonhelpers.h"
 
 // AppConfig is a singleton construct for accessing the application's configuration.
 // singleton design borrowed from:
@@ -50,13 +53,11 @@ class AppConfig {
     }
   }
 
-  QString saveLocation = Constants::configLocation();
-
-  void readConfig() {
-    QFile configFile(saveLocation);
+  void readConfig(QString location=Constants::configLocation()) {
+    QFile configFile(location);
     if (!configFile.open(QIODevice::ReadOnly)) {
       if (configFile.exists()) {
-        throw FileError::mkError("Error reading config file", saveLocation.toStdString(),
+        throw FileError::mkError("Error reading config file", location.toStdString(),
                                  configFile.error());
       }
       try {
@@ -70,26 +71,17 @@ class AppConfig {
 
     QByteArray data = configFile.readAll();
     if (configFile.error() != QFile::NoError) {
-      throw FileError::mkError("Error reading config file", saveLocation.toStdString(),
+      throw FileError::mkError("Error reading config file", location.toStdString(),
                                configFile.error());
     }
 
-    QJsonParseError err;
-    QJsonDocument doc = QJsonDocument::fromJson(data, &err);
-    if (err.error != QJsonParseError::NoError) {
-      // ignoring specific type -- unlikely to occur in practice.
+    auto result = parseJSONItem<QString>(data, [this](QJsonObject src) {
+      applyConfig(src);
+      return "";
+    });
+    if (result.isNull()) {
       throw std::runtime_error("Unable to parse config file");
     }
-
-    this->evidenceRepo = doc["evidenceRepo"].toString();
-    this->accessKey = doc["accessKey"].toString();
-    this->secretKey = doc["secretKey"].toString();
-    this->apiURL = doc["apiURL"].toString();
-    this->screenshotExec = doc["screenshotCommand"].toString();
-    this->screenshotShortcutCombo = doc["screenshotShortcut"].toString();
-    this->captureWindowExec = doc["captureWindowExec"].toString();
-    this->captureWindowShortcut = doc["captureWindowShortcut"].toString();
-    this->captureCodeblockShortcut = doc["captureCodeblockShortcut"].toString();
   }
 
   void writeDefaultConfig() {
@@ -109,8 +101,30 @@ class AppConfig {
   }
 
  public:
-  void writeConfig() {
-    QJsonObject root = QJsonObject();  // QFiles close automatically, so no need for close here.
+
+  void applyConfig(QJsonObject src) {
+    std::vector<std::pair<QString, QString*>> fields = {
+        std::pair<QString, QString*>("evidenceRepo", &evidenceRepo),
+        std::pair<QString, QString*>("accessKey", &accessKey),
+        std::pair<QString, QString*>("secretKey", &secretKey),
+        std::pair<QString, QString*>("apiURL", &apiURL),
+        std::pair<QString, QString*>("screenshotCommand", &screenshotExec),
+        std::pair<QString, QString*>("screenshotShortcut", &screenshotShortcutCombo),
+        std::pair<QString, QString*>("captureWindowExec", &captureWindowExec),
+        std::pair<QString, QString*>("captureWindowShortcut", &captureWindowShortcut),
+        std::pair<QString, QString*>("captureCodeblockShortcut", &captureCodeblockShortcut),
+        };
+
+    for (auto fieldPair : fields) {
+      QJsonValue val = src.value(fieldPair.first);
+      if (!val.isUndefined() && val.isString()) {
+        *fieldPair.second = val.toString();
+      }
+    }
+  }
+
+  QJsonObject serializeConfig() {
+    QJsonObject root;
     root["evidenceRepo"] = evidenceRepo;
     root["accessKey"] = accessKey;
     root["secretKey"] = secretKey;
@@ -120,24 +134,25 @@ class AppConfig {
     root["captureWindowExec"] = captureWindowExec;
     root["captureWindowShortcut"] = captureWindowShortcut;
     root["captureCodeblockShortcut"] = captureCodeblockShortcut;
-
-    auto saveRoot = saveLocation.left(saveLocation.lastIndexOf("/"));
-    QDir().mkpath(saveRoot);
-    QFile configFile(saveLocation);
-    if (!configFile.open(QIODevice::WriteOnly)) {
-      throw FileError::mkError("Error writing config file", saveLocation.toStdString(),
-                               configFile.error());
-    }
-
-    QJsonDocument doc(root);
-    auto written = configFile.write(doc.toJson());
-    if (written == -1) {
-      throw FileError::mkError("Error writing config file", saveLocation.toStdString(),
-                               configFile.error());
-    }
-
-    return;
+    return root;
   }
+
+  void writeConfig(QString alternateSavePath="") {
+    QString writeLoc = alternateSavePath == "" ? Constants::configLocation() : alternateSavePath;
+
+    auto configContent = QJsonDocument(serializeConfig()).toJson();
+
+    try {
+      FileHelpers::mkdirs(writeLoc, true); // ensure the path exists
+      FileHelpers::writeFile(writeLoc, configContent);
+    }
+    catch(const FileError &e) {
+      // rewrap error for easier identification
+      throw FileError::mkError("Error writing config file", writeLoc.toStdString(),
+                               e.fileDeviceError);
+    }
+    return;
+   }
 };
 
 #endif  // DATA_H

--- a/src/db/databaseconnection.cpp
+++ b/src/db/databaseconnection.cpp
@@ -26,6 +26,7 @@ DatabaseConnection::DatabaseConnection(QString dbPath, QString databaseName) {
     auto db = QSqlDatabase::addDatabase(dbDriver, dbName);
     QDir().mkpath(FileHelpers::getDirname(dbPath));
     db.setDatabaseName(dbPath);
+    this->_dbPath = dbPath;
   }
   else {
     throw DBDriverUnavailableError("SQLite");
@@ -435,4 +436,8 @@ QSqlDatabase DatabaseConnection::getDB() {
     return QSqlDatabase::database();
   }
   return QSqlDatabase::database(dbName);
+}
+
+QString DatabaseConnection::getDatabasePath() {
+  return _dbPath;
 }

--- a/src/db/databaseconnection.cpp
+++ b/src/db/databaseconnection.cpp
@@ -131,7 +131,6 @@ std::vector<model::Tag> DatabaseConnection::getTagsForEvidenceID(qint64 evidence
     auto tag = model::Tag(getTagQuery.value("id").toLongLong(),
                           getTagQuery.value("tag_id").toLongLong(),
                           getTagQuery.value("name").toString());
-    tag.setEvidenceID(evidenceID);
     tags.emplace_back(tag);
   }
   return tags;

--- a/src/db/databaseconnection.cpp
+++ b/src/db/databaseconnection.cpp
@@ -200,6 +200,10 @@ DBQuery DatabaseConnection::buildGetEvidenceWithFiltersQuery(const EvidenceFilte
   return DBQuery(query, values);
 }
 
+void DatabaseConnection::updateEvidencePath(QString newPath, qint64 evidenceID) {
+  executeQuery(&db, "UPDATE evidence SET path=? WHERE id=?", {newPath, evidenceID});
+}
+
 std::vector<model::Evidence> DatabaseConnection::getEvidenceWithFilters(
     const EvidenceFilters &filters) {
   auto dbQuery = buildGetEvidenceWithFiltersQuery(filters);

--- a/src/db/databaseconnection.h
+++ b/src/db/databaseconnection.h
@@ -59,6 +59,7 @@ class DatabaseConnection {
   qint64 createEvidence(const QString &filepath, const QString &operationSlug,
                         const QString &contentType);
   qint64 createFullEvidence(const model::Evidence &evidence);
+  qint64 createFullEvidenceWithID(const model::Evidence &evidence);
 
   void updateEvidenceDescription(const QString &newDescription, qint64 evidenceID);
   void updateEvidenceError(const QString &errorText, qint64 evidenceID);
@@ -68,6 +69,12 @@ class DatabaseConnection {
 
   void deleteEvidence(qint64 evidenceID);
 
+  /// createEvidenceExportView duplicates the normal database with only a subset of evidence present,
+  /// as well as related data (e.g. tags)
+  ///
+  /// Note that currently, this simply exports everything. This is included as a way to limit sharing
+  /// in the future.
+  static std::vector<model::Evidence> createEvidenceExportView(QString pathToExport, EvidenceFilters filters, DatabaseConnection* runningDB);
   std::vector<model::Tag> getTagsForEvidenceID(qint64 evidenceID);
 
  private:

--- a/src/db/databaseconnection.h
+++ b/src/db/databaseconnection.h
@@ -48,6 +48,7 @@ class DatabaseConnection {
   void updateEvidenceDescription(const QString &newDescription, qint64 evidenceID);
   void updateEvidenceError(const QString &errorText, qint64 evidenceID);
   void updateEvidenceSubmitted(qint64 evidenceID);
+  void updateEvidencePath(QString newPath, qint64 evidenceID);
   void setEvidenceTags(const std::vector<model::Tag> &newTags, qint64 evidenceID);
 
   void deleteEvidence(qint64 evidenceID);

--- a/src/db/databaseconnection.h
+++ b/src/db/databaseconnection.h
@@ -37,7 +37,7 @@ class DBQuery {
 
 class DatabaseConnection {
  public:
-  DatabaseConnection(QString dbPath, QString databaseName);
+  DatabaseConnection(const QString& dbPath, QString databaseName);
 
   /**
    * @brief withConnection acts as a context manager for a single database connection. The goal for
@@ -49,7 +49,8 @@ class DatabaseConnection {
    * @param actions A function that will execute after a connection is established. This is where
    * all db interactions should occur.
    */
-  static void withConnection(QString dbPath, QString dbName, std::function<void(DatabaseConnection)>actions);
+  static void withConnection(const QString& dbPath, const QString &dbName,
+                             const std::function<void(DatabaseConnection)> &actions);
 
   void connect();
   void close() noexcept;
@@ -68,22 +69,28 @@ class DatabaseConnection {
   void updateEvidenceDescription(const QString &newDescription, qint64 evidenceID);
   void updateEvidenceError(const QString &errorText, qint64 evidenceID);
   void updateEvidenceSubmitted(qint64 evidenceID);
-  void updateEvidencePath(QString newPath, qint64 evidenceID);
+  void updateEvidencePath(const QString& newPath, qint64 evidenceID);
   void setEvidenceTags(const std::vector<model::Tag> &newTags, qint64 evidenceID);
   void batchCopyTags(const std::vector<model::Tag> &allTags);
-  std::vector<model::Tag> getFullTagsForEvidenceIDs(std::vector<qint64> evidenceIDs);
+  std::vector<model::Tag> getFullTagsForEvidenceIDs(const std::vector<qint64>& evidenceIDs);
 
   void deleteEvidence(qint64 evidenceID);
 
-  /// createEvidenceExportView duplicates the normal database with only a subset of evidence present,
-  /// as well as related data (e.g. tags)
+  /// createEvidenceExportView duplicates the normal database with only a subset of evidence
+  /// present, as well as related data (e.g. tags)
   ///
-  /// Note that currently, this simply exports everything. This is included as a way to limit sharing
-  /// in the future.
-  static std::vector<model::Evidence> createEvidenceExportView(QString pathToExport, EvidenceFilters filters, DatabaseConnection* runningDB);
+  /// Note that currently, this simply exports everything. This is included as a way to limit
+  /// sharing in the future.
+  static std::vector<model::Evidence> createEvidenceExportView(const QString& pathToExport,
+                                                               const EvidenceFilters& filters,
+                                                               DatabaseConnection *runningDB);
   std::vector<model::Tag> getTagsForEvidenceID(qint64 evidenceID);
 
+  /// getDatabasePath returns the filepath associated with the loaded database
   QString getDatabasePath();
+
+ public:
+  const unsigned long SQLITE_MAX_VARS = 999;
 
  private:
   QString dbName = "";
@@ -112,8 +119,8 @@ class DatabaseConnection {
    * @param encodeValues A function that, given a row index, will return a QVariantList with each column's data for that row
    * @param rowInsertTemplate An optional string that can be used to define each row's values. Defaults to (?, ..., ?)
    */
-  void batchInsert(QString baseQuery, unsigned int varsPerRow, unsigned int numRows,
-               FieldEncoderFunc encodeValues, QString rowInsertTemplate="");
+  void batchInsert(const QString& baseQuery, unsigned int varsPerRow, unsigned int numRows,
+                   const FieldEncoderFunc& encodeValues, QString rowInsertTemplate="");
 
   /**
    * @brief batchQuery batches a query with many variables into as few queries as possible.
@@ -125,8 +132,9 @@ class DatabaseConnection {
    * @param decodeRows A function that can be used to retrieve the rows from the result set
    * @param variableTemplate An optional string that can be used to define how variables are handled. Defaults to ?,...,?
    */
-  void batchQuery(QString baseQuery, unsigned int varsPerRow, unsigned int numRows,
-               FieldEncoderFunc encodeValues, RowDecoderFunc decodeRows, QString variableTemplate="");
+  void batchQuery(const QString &baseQuery, unsigned int varsPerRow, unsigned int numRows,
+                  const FieldEncoderFunc &encodeValues, const RowDecoderFunc& decodeRows,
+                  QString variableTemplate = "");
 };
 
 #endif  // DATABASECONNECTION_H

--- a/src/db/databaseconnection.h
+++ b/src/db/databaseconnection.h
@@ -77,8 +77,11 @@ class DatabaseConnection {
   static std::vector<model::Evidence> createEvidenceExportView(QString pathToExport, EvidenceFilters filters, DatabaseConnection* runningDB);
   std::vector<model::Tag> getTagsForEvidenceID(qint64 evidenceID);
 
+  QString getDatabasePath();
+
  private:
   QString dbName = "";
+  QString _dbPath = "";
 
   void migrateDB();
   QSqlDatabase getDB();

--- a/src/db/query_result.h
+++ b/src/db/query_result.h
@@ -1,0 +1,31 @@
+#ifndef QUERY_RESULT_H
+#define QUERY_RESULT_H
+
+#include <QSqlError>
+#include <QSqlQuery>
+
+#endif // QUERY_RESULT_H
+
+/**
+ * @brief The QueryResult class is a small container for representing a post "query.exec" state
+ * for a given query. Note that this class does not *require* that an exec is made. Notably,
+ * if a prepared statement is created, and fails, then this could be reflected by this class.
+ */
+class QueryResult {
+ public:
+  QueryResult(){}
+  QueryResult(QSqlQuery query) {
+    this->query = query;
+    this->err = query.lastError();
+    this->success = err.type() == QSqlError::NoError;
+  }
+
+ public:
+  /// success is a shorthand to determine if the last error was actually NoError
+  bool success = false;
+  /// query is the result of the underlying query, in whatever state it is in
+  QSqlQuery query;
+
+  /// err is a shorthand for QSqlQuery.lastError()
+  QSqlError err;
+};

--- a/src/exceptions/fileerror.h
+++ b/src/exceptions/fileerror.h
@@ -10,9 +10,11 @@
 
 class FileError : public std::runtime_error {
  public:
+  /// mkError constructs an std::runtime_error with the given details.
   static FileError mkError(QString msg, QString path, QFileDevice::FileError err) {
     return FileError::mkError(msg.toStdString(), path.toStdString(), err);
   }
+  /// mkError constructs an std::runtime_error with the given details.
   static FileError mkError(std::string msg, std::string path, QFileDevice::FileError err) {
     std::string suberror;
     switch (err) {

--- a/src/exceptions/fileerror.h
+++ b/src/exceptions/fileerror.h
@@ -10,6 +10,9 @@
 
 class FileError : public std::runtime_error {
  public:
+  static FileError mkError(QString msg, QString path, QFileDevice::FileError err) {
+    return FileError::mkError(msg.toStdString(), path.toStdString(), err);
+  }
   static FileError mkError(std::string msg, std::string path, QFileDevice::FileError err) {
     std::string suberror;
     switch (err) {

--- a/src/exceptions/fileerror.h
+++ b/src/exceptions/fileerror.h
@@ -59,8 +59,13 @@ class FileError : public std::runtime_error {
         suberror = "Actually, no error occurred -- just bad programming.";
         break;
     }
-    return msg + " (path: " + path + "): " + suberror;
+    FileError wrappedErr(msg + " (path: " + path + "): " + suberror);
+    wrappedErr.fileDeviceError = err;
+    return wrappedErr;
   }
+
+ public:
+  QFileDevice::FileError fileDeviceError;
 
  private:
   FileError(std::string msg) : std::runtime_error(msg) {}

--- a/src/forms/porting/porting_dialog.cpp
+++ b/src/forms/porting/porting_dialog.cpp
@@ -178,7 +178,7 @@ QString PortingDialog::getPortPath() {
   return portPath;
 }
 
-void PortingDialog::doExport(porting::SystemManifest* manifest, QString exportPath) {
+void PortingDialog::doExport(porting::SystemManifest* manifest, const QString& exportPath) {
   porting::SystemManifestExportOptions options;
   options.exportDb = portEvidenceCheckBox->isChecked();
   options.exportConfig = portConfigCheckBox->isChecked();
@@ -204,7 +204,7 @@ void PortingDialog::doExport(porting::SystemManifest* manifest, QString exportPa
   emit onWorkComplete(true);
 }
 
-porting::SystemManifest* PortingDialog::doPreImport(QString pathToSystemManifest) {
+porting::SystemManifest* PortingDialog::doPreImport(const QString& pathToSystemManifest) {
   porting::SystemManifest* manifest = nullptr;
   try {
     manifest = porting::SystemManifest::readManifest(pathToSystemManifest);

--- a/src/forms/porting/porting_dialog.cpp
+++ b/src/forms/porting/porting_dialog.cpp
@@ -147,10 +147,12 @@ void PortingDialog::onSubmitPressed() {
       return;
     }
     portAction = [this](){ doImport(executedManifest); };
+    portPath = FileHelpers::getDirname(portingPath);
   }
   else {
     executedManifest = new porting::SystemManifest();
     portAction = [this, portingPath](){ doExport(executedManifest, portingPath); };
+    portPath = portingPath;
   }
 
   connect(executedManifest, &porting::SystemManifest::onReady, progressBar, &QProgressBar::setMaximum);
@@ -172,6 +174,11 @@ void PortingDialog::onPortComplete(bool success) {
   progressBar->setRange(0, 1);
   progressBar->setValue(1);
   submitButton->setEnabled(true);
+  emit portCompleted(portPath);
+}
+
+QString PortingDialog::getPortPath() {
+  return portPath;
 }
 
 void PortingDialog::doExport(porting::SystemManifest* manifest, QString exportPath) {

--- a/src/forms/porting/porting_dialog.cpp
+++ b/src/forms/porting/porting_dialog.cpp
@@ -1,0 +1,197 @@
+#include "porting_dialog.h"
+
+#include <QTimer>
+#include <QFileDialog>
+#include <iostream>
+
+#include "porting/system_manifest.h"
+
+PortingDialog::PortingDialog(PortType dialogType, DatabaseConnection* db, QWidget *parent)
+  : QDialog(parent) {
+  this->dialogType = dialogType;
+  this->db = db;
+
+  buildUi();
+  wireUi();
+}
+
+PortingDialog::~PortingDialog() {
+  delete closeWindowAction;
+
+  delete _selectFileLabel;
+  delete portConfigCheckBox;
+  delete portEvidenceCheckBox;
+  delete submitButton;
+  delete pathTextBox;
+  delete progressBar;
+  delete portStatusLabel;
+
+  delete gridLayout;
+}
+
+void PortingDialog::buildUi() {
+  gridLayout = new QGridLayout(this);
+
+  _selectFileLabel = new QLabel(this);
+  portStatusLabel = new QLabel(this);
+
+  submitButton = new QPushButton(this);
+  browseButton = new QPushButton("Browse", this);
+  pathTextBox = new QLineEdit(this);
+  portConfigCheckBox = new QCheckBox("Include Config", this);
+  portConfigCheckBox->setChecked(true);
+  portEvidenceCheckBox = new QCheckBox("Include Evidence", this);
+  portEvidenceCheckBox->setChecked(true);
+  progressBar = new QProgressBar(this);
+  // set some initial values to provide a
+  progressBar->setRange(0, 1);
+  progressBar->setValue(0);
+
+
+  if (dialogType == Import) {
+    submitButton->setText("Import");
+    _selectFileLabel->setText("Select import file");
+    this->setWindowTitle("Import Data");
+  }
+  else {
+    submitButton->setText("Export");
+    _selectFileLabel->setText("Export Directory");
+    this->setWindowTitle("Export Data");
+  }
+
+  // Layout
+  /*        0                 1           2
+       +---------------+-------------+--------------+
+    0  | File  Lbl     | [path TB]   | Browse Btn   |
+       +---------------+-------------+--------------+
+    1  |                 With Cfg CB                |
+       +---------------+-------------+--------------+
+    2  |                 With data CB               |
+       +---------------+-------------+--------------+
+    3  |                 Progress Bar               |
+       +---------------+-------------+--------------+
+    4  |                Porting Status              |
+       +---------------+-------------+--------------+
+    5  | <None>        | <None>      | Submit Btn   |
+       +---------------+-------------+--------------+
+  */
+
+  // row 0
+  gridLayout->addWidget(_selectFileLabel, 0, 0);
+  gridLayout->addWidget(pathTextBox, 0, 1);
+  gridLayout->addWidget(browseButton, 0, 2);
+
+  // row 1
+  gridLayout->addWidget(portConfigCheckBox, 1, 0, 1, gridLayout->columnCount());
+
+  // row 2
+  gridLayout->addWidget(portEvidenceCheckBox, 2, 0, 1, gridLayout->columnCount());
+
+  // row 3
+  gridLayout->addWidget(progressBar, 3, 0, 1, gridLayout->columnCount());
+
+  // row 4
+  gridLayout->addWidget(portStatusLabel, 4, 0, 1, gridLayout->columnCount());
+
+  // row 5
+  gridLayout->addWidget(submitButton, 5, 2);
+
+  closeWindowAction = new QAction(this);
+  closeWindowAction->setShortcut(QKeySequence::Close);
+  this->addAction(closeWindowAction);
+
+  this->setLayout(gridLayout);
+  this->resize(500, 1);
+}
+
+void PortingDialog::wireUi() {
+  auto btnClicked = &QPushButton::clicked;
+
+  connect(submitButton, btnClicked, this, &PortingDialog::onSubmitPressed);
+  connect(browseButton, btnClicked, this, &PortingDialog::onBrowsePresed);
+}
+
+void PortingDialog::onSubmitPressed() {
+  if (pathTextBox->text().trimmed().isEmpty()) {
+    portStatusLabel->setText("Please set a valid path first");
+    return;
+  }
+
+  submitButton->setEnabled(false);
+  progressBar->setRange(0, 0);
+
+  // the below should (maybe) be done in a separate thread
+  if (dialogType == Import) {
+    portStatusLabel->setText("Parsing input...");
+    doImport();
+  }
+  else {
+    portStatusLabel->setText("Gathering data...");
+    doExport();
+  }
+
+//  QTimer::singleShot(10000, [this](){
+//    onPortComplete(true);
+//  });
+}
+
+void PortingDialog::onBrowsePresed() {
+  auto browseStart = pathTextBox->text();
+  browseStart = QFile(browseStart).exists() ? browseStart : QDir::homePath();
+  QString selectedFile;
+  if (dialogType == Import) {
+    selectedFile = QFileDialog::getOpenFileName(this, tr("Select an import file"),
+                                                browseStart, tr("System Migration json (system.json);;All Files(*)"));
+  }
+  else {
+    selectedFile = QFileDialog::getExistingDirectory(this, tr("Select an export directory"),
+                                                      browseStart, QFileDialog::ShowDirsOnly);
+  }
+  if (!selectedFile.isNull()) {
+    pathTextBox->setText(QDir::toNativeSeparators(selectedFile));
+  }
+}
+
+void PortingDialog::onPortComplete(bool success) {
+  submitButton->setEnabled(true);
+}
+
+void PortingDialog::doExport() {
+  sync::SystemManifestExportOptions options;
+  options.exportDb = portEvidenceCheckBox->isChecked();
+  options.exportConfig = portConfigCheckBox->isChecked();
+  sync::SystemManifest manifest;
+  try {
+    manifest.exportManifest(db, pathTextBox->text(), options);
+    portStatusLabel->setText("Export Complete");
+  }
+  catch(const FileError &e) {
+    std::cout << "got an error during export: " << e.what() << std::endl;
+  }
+  catch(const QSqlError &e) {
+    std::cout << "got an sql error during export: " << e.text().toStdString() << std::endl;
+  }
+
+  onPortComplete(true);
+}
+
+void PortingDialog::doImport() {
+  sync::SystemManifestImportOptions options;
+  options.importDb = portEvidenceCheckBox->isChecked() ? options.Merge : options.None;
+  options.importConfig = portConfigCheckBox->isChecked();
+  try {
+    auto manifest = sync::SystemManifest::readManifest(pathTextBox->text());
+    manifest.applyManifest(options, db);
+    portStatusLabel->setText("Import Complete");
+  }
+  catch(const FileError &e) {
+    portStatusLabel->setText(QString("Error during import: ") + e.what());
+    std::cout << "got an error during import: " << e.what() << std::endl;
+  }
+  catch(const QSqlError &e) {
+    portStatusLabel->setText(QString("Error during import: ") + e.text());
+    std::cout << "got an sql error during import: " << e.text().toStdString() << std::endl;
+  }
+
+//  onPortComplete(true);
+}

--- a/src/forms/porting/porting_dialog.cpp
+++ b/src/forms/porting/porting_dialog.cpp
@@ -124,7 +124,22 @@ void PortingDialog::onBrowsePresed() {
   }
 }
 
+void PortingDialog::resetForm() {
+    portDone = false;
+    pathTextBox->clear();
+    progressBar->setRange(0, 1);
+    progressBar->setValue(0);
+    portStatusLabel->setText("");
+    portConfigCheckBox->setCheckState(Qt::Unchecked);
+    portEvidenceCheckBox->setCheckState(Qt::Unchecked);
+    submitButton->setText(dialogType == Import ? "Import" : "Export");
+}
+
 void PortingDialog::onSubmitPressed() {
+  if (portDone) {
+      this->close();
+      resetForm();
+  }
   auto portingPath = pathTextBox->text().trimmed();
   if (pathTextBox->text().trimmed().isEmpty()) {
     portStatusLabel->setText("Please set a valid path first");
@@ -163,6 +178,8 @@ void PortingDialog::onSubmitPressed() {
 void PortingDialog::onPortComplete(bool success) {
   if(success) {
     portStatusLabel->setText(dialogType == Import ? "Import Complete" : "Export Complete");
+    submitButton->setText("Close");
+    portDone = true;
   }
   if(executedManifest != nullptr) {
     delete executedManifest;

--- a/src/forms/porting/porting_dialog.cpp
+++ b/src/forms/porting/porting_dialog.cpp
@@ -149,13 +149,13 @@ void PortingDialog::onSubmitPressed() {
     portAction = [this](){ doImport(executedManifest); };
   }
   else {
-    executedManifest = new sync::SystemManifest();
+    executedManifest = new porting::SystemManifest();
     portAction = [this, portingPath](){ doExport(executedManifest, portingPath); };
   }
 
-  connect(executedManifest, &sync::SystemManifest::onReady, progressBar, &QProgressBar::setMaximum);
-  connect(executedManifest, &sync::SystemManifest::onFileProcessed, progressBar, &QProgressBar::setValue);
-  connect(executedManifest, &sync::SystemManifest::onStatusUpdate, portStatusLabel, &QLabel::setText);
+  connect(executedManifest, &porting::SystemManifest::onReady, progressBar, &QProgressBar::setMaximum);
+  connect(executedManifest, &porting::SystemManifest::onFileProcessed, progressBar, &QProgressBar::setValue);
+  connect(executedManifest, &porting::SystemManifest::onStatusUpdate, portStatusLabel, &QLabel::setText);
   connect(this, &PortingDialog::onWorkComplete, this, &PortingDialog::onPortComplete);
 
   QtConcurrent::run(portAction);
@@ -174,8 +174,8 @@ void PortingDialog::onPortComplete(bool success) {
   submitButton->setEnabled(true);
 }
 
-void PortingDialog::doExport(sync::SystemManifest* manifest, QString exportPath) {
-  sync::SystemManifestExportOptions options;
+void PortingDialog::doExport(porting::SystemManifest* manifest, QString exportPath) {
+  porting::SystemManifestExportOptions options;
   options.exportDb = portEvidenceCheckBox->isChecked();
   options.exportConfig = portConfigCheckBox->isChecked();
 
@@ -200,10 +200,10 @@ void PortingDialog::doExport(sync::SystemManifest* manifest, QString exportPath)
   emit onWorkComplete(true);
 }
 
-sync::SystemManifest* PortingDialog::doPreImport(QString pathToSystemManifest) {
-  sync::SystemManifest* manifest = nullptr;
+porting::SystemManifest* PortingDialog::doPreImport(QString pathToSystemManifest) {
+  porting::SystemManifest* manifest = nullptr;
   try {
-    manifest = sync::SystemManifest::readManifest(pathToSystemManifest);
+    manifest = porting::SystemManifest::readManifest(pathToSystemManifest);
   }
   catch(const FileError& e) {
     portStatusLabel->setText("Unable to parse system file.");
@@ -212,8 +212,8 @@ sync::SystemManifest* PortingDialog::doPreImport(QString pathToSystemManifest) {
   return manifest;
 }
 
-void PortingDialog::doImport(sync::SystemManifest* manifest) {
-  sync::SystemManifestImportOptions options;
+void PortingDialog::doImport(porting::SystemManifest* manifest) {
+  porting::SystemManifestImportOptions options;
   options.importDb = portEvidenceCheckBox->isChecked() ? options.Merge : options.None;
   options.importConfig = portConfigCheckBox->isChecked();
 

--- a/src/forms/porting/porting_dialog.cpp
+++ b/src/forms/porting/porting_dialog.cpp
@@ -42,9 +42,6 @@ void PortingDialog::buildUi() {
   portEvidenceCheckBox = new QCheckBox("Include Evidence", this);
   portEvidenceCheckBox->setChecked(true);
   progressBar = new QProgressBar(this);
-  // set some initial values to provide a
-  progressBar->setRange(0, 1);
-  progressBar->setValue(0);
 
 
   if (dialogType == Import) {

--- a/src/forms/porting/porting_dialog.h
+++ b/src/forms/porting/porting_dialog.h
@@ -27,6 +27,12 @@ class PortingDialog : public QDialog {
   explicit PortingDialog(PortType dialogType, DatabaseConnection* db, QWidget *parent = nullptr);
   ~PortingDialog();
 
+ public:
+  QString getPortPath();
+
+ signals:
+  void portCompleted(QString path);
+
  private:
   /// buildUi creates the window structure.
   void buildUi();
@@ -49,6 +55,7 @@ class PortingDialog : public QDialog {
   /// executedManifest contains a pointer to the system manifest used to import/export data
   /// Saved so that it can be cleaned up post-execution
   porting::SystemManifest* executedManifest = nullptr;
+  QString portPath;
 
   PortType dialogType;
   QAction* closeWindowAction = nullptr;

--- a/src/forms/porting/porting_dialog.h
+++ b/src/forms/porting/porting_dialog.h
@@ -64,6 +64,9 @@ class PortingDialog : public QDialog {
   /// Import and Export dialogs
   void onBrowsePresed();
 
+  /// resetForm places the form back to it's original configuration.
+  void resetForm();
+
   /// doExport begins the export process with the given System manifest and export path
   void doExport(porting::SystemManifest* manifest, const QString& exportPath);
 
@@ -84,6 +87,7 @@ class PortingDialog : public QDialog {
  private:
   QString portPath = "";
   PortType dialogType;
+  bool portDone = false;
 
   DatabaseConnection* db; // borrowed
 

--- a/src/forms/porting/porting_dialog.h
+++ b/src/forms/porting/porting_dialog.h
@@ -12,6 +12,7 @@
 #include <QWidget>
 
 #include "db/databaseconnection.h"
+#include "porting/system_manifest.h"
 
 class PortingDialog : public QDialog {
   Q_OBJECT
@@ -35,12 +36,19 @@ class PortingDialog : public QDialog {
   void onSubmitPressed();
   void onBrowsePresed();
 
-  void doExport();
-  void doImport();
+  void doExport(sync::SystemManifest* manifest, QString exportPath);
+  sync::SystemManifest* doPreImport(QString pathToSystemManifest);
+  void doImport(sync::SystemManifest* manifest);
   void onPortComplete(bool success);
+
+ signals:
+  void onWorkComplete(bool success);
 
  private:
   DatabaseConnection* db; // borrowed
+  /// executedManifest contains a pointer to the system manifest used to import/export data
+  /// Saved so that it can be cleaned up post-execution
+  sync::SystemManifest* executedManifest = nullptr;
 
   PortType dialogType;
   QAction* closeWindowAction = nullptr;

--- a/src/forms/porting/porting_dialog.h
+++ b/src/forms/porting/porting_dialog.h
@@ -36,9 +36,9 @@ class PortingDialog : public QDialog {
   void onSubmitPressed();
   void onBrowsePresed();
 
-  void doExport(sync::SystemManifest* manifest, QString exportPath);
-  sync::SystemManifest* doPreImport(QString pathToSystemManifest);
-  void doImport(sync::SystemManifest* manifest);
+  void doExport(porting::SystemManifest* manifest, QString exportPath);
+  porting::SystemManifest* doPreImport(QString pathToSystemManifest);
+  void doImport(porting::SystemManifest* manifest);
   void onPortComplete(bool success);
 
  signals:
@@ -48,7 +48,7 @@ class PortingDialog : public QDialog {
   DatabaseConnection* db; // borrowed
   /// executedManifest contains a pointer to the system manifest used to import/export data
   /// Saved so that it can be cleaned up post-execution
-  sync::SystemManifest* executedManifest = nullptr;
+  porting::SystemManifest* executedManifest = nullptr;
 
   PortType dialogType;
   QAction* closeWindowAction = nullptr;

--- a/src/forms/porting/porting_dialog.h
+++ b/src/forms/porting/porting_dialog.h
@@ -65,11 +65,11 @@ class PortingDialog : public QDialog {
   void onBrowsePresed();
 
   /// doExport begins the export process with the given System manifest and export path
-  void doExport(porting::SystemManifest* manifest, QString exportPath);
+  void doExport(porting::SystemManifest* manifest, const QString& exportPath);
 
   /// doPreImport opens and parses the provided path to the system manifest. A small amount of
   /// validation occurs. If any errors are encountered, then the import is cancelled
-  porting::SystemManifest* doPreImport(QString pathToSystemManifest);
+  porting::SystemManifest* doPreImport(const QString& pathToSystemManifest);
   /// doImport begins the import process with the given system manifest
   void doImport(porting::SystemManifest* manifest);
 
@@ -82,7 +82,7 @@ class PortingDialog : public QDialog {
   void onWorkComplete(bool success);
 
  private:
-  QString portPath;
+  QString portPath = "";
   PortType dialogType;
 
   DatabaseConnection* db; // borrowed

--- a/src/forms/porting/porting_dialog.h
+++ b/src/forms/porting/porting_dialog.h
@@ -1,0 +1,61 @@
+#ifndef IMPORTDIALOG_H
+#define IMPORTDIALOG_H
+
+#include <QAction>
+#include <QCheckBox>
+#include <QDialog>
+#include <QGridLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QWidget>
+
+#include "db/databaseconnection.h"
+
+class PortingDialog : public QDialog {
+  Q_OBJECT
+
+ public:
+  enum PortType {
+    Import,
+    Export
+  };
+
+ public:
+  explicit PortingDialog(PortType dialogType, DatabaseConnection* db, QWidget *parent = nullptr);
+  ~PortingDialog();
+
+ private:
+  /// buildUi creates the window structure.
+  void buildUi();
+  /// wireUi connects the components to each other.
+  void wireUi();
+
+  void onSubmitPressed();
+  void onBrowsePresed();
+
+  void doExport();
+  void doImport();
+  void onPortComplete(bool success);
+
+ private:
+  DatabaseConnection* db; // borrowed
+
+  PortType dialogType;
+  QAction* closeWindowAction = nullptr;
+
+  // UI Components
+  QGridLayout* gridLayout = nullptr;
+  QLabel* _selectFileLabel = nullptr;
+  QLabel* portStatusLabel = nullptr;
+
+  QPushButton* submitButton = nullptr;
+  QPushButton* browseButton = nullptr;
+  QLineEdit* pathTextBox = nullptr;
+  QProgressBar* progressBar = nullptr;
+  QCheckBox* portConfigCheckBox = nullptr;
+  QCheckBox* portEvidenceCheckBox = nullptr;
+};
+
+#endif // IMPORTDIALOG_H

--- a/src/forms/porting/porting_dialog.h
+++ b/src/forms/porting/porting_dialog.h
@@ -14,23 +14,42 @@
 #include "db/databaseconnection.h"
 #include "porting/system_manifest.h"
 
+/**
+ * @brief The PortingDialog class renders a dialog window allowing a user to import or export content and settings.
+ * The UI presented is dependent on the underlying dialogType. Specifying Import will render an import window,
+ * while Export will render an export window.
+ * @see PortType
+ */
 class PortingDialog : public QDialog {
   Q_OBJECT
 
  public:
+  /// PortType is a small enum indicating if the PortingDialog renders an import or export window
   enum PortType {
+    /// Import denotes that all actions and dialog options should be rendered for import purposes
     Import,
+    /// Export denotes that all actions and dialog options should be rendered for export purposes
     Export
   };
 
  public:
+  /**
+   * @brief PortingDialog constructs a new Dialog window. After this method is called, the UI will be rendered and wired.
+   * @param dialogType controls whether the rendered dialog window is used for Import or Export purposes
+   * @param db is a reference to the standard, running database.
+   * @param parent is used by the underlying QDialog constructor
+   */
   explicit PortingDialog(PortType dialogType, DatabaseConnection* db, QWidget *parent = nullptr);
   ~PortingDialog();
 
  public:
+  /// getPortPath retrieves the path used to import or export (note: this is always directory, even
+  /// when Importing from a specific file)
   QString getPortPath();
 
  signals:
+  /// portCompleted is called when an import or export finishes.
+  /// @param path contains the import or export directory used
   void portCompleted(QString path);
 
  private:
@@ -39,25 +58,39 @@ class PortingDialog : public QDialog {
   /// wireUi connects the components to each other.
   void wireUi();
 
+  /// onSubmitPressed preps an import/export and routes the action to doImport or doExport
   void onSubmitPressed();
+  /// onBrowsePressed renders a QFileDialog window (for opening). The behavior is specific for
+  /// Import and Export dialogs
   void onBrowsePresed();
 
+  /// doExport begins the export process with the given System manifest and export path
   void doExport(porting::SystemManifest* manifest, QString exportPath);
+
+  /// doPreImport opens and parses the provided path to the system manifest. A small amount of
+  /// validation occurs. If any errors are encountered, then the import is cancelled
   porting::SystemManifest* doPreImport(QString pathToSystemManifest);
+  /// doImport begins the import process with the given system manifest
   void doImport(porting::SystemManifest* manifest);
+
+  /// onPortComplete is a common post-port action/cleanup for both import and export.
   void onPortComplete(bool success);
 
  signals:
+  /// onWorkComplete is called as the final step in import/export. This signals to the dialog that
+  /// onPortComplete can be called.
   void onWorkComplete(bool success);
 
  private:
+  QString portPath;
+  PortType dialogType;
+
   DatabaseConnection* db; // borrowed
+
   /// executedManifest contains a pointer to the system manifest used to import/export data
   /// Saved so that it can be cleaned up post-execution
   porting::SystemManifest* executedManifest = nullptr;
-  QString portPath;
 
-  PortType dialogType;
   QAction* closeWindowAction = nullptr;
 
   // UI Components

--- a/src/helpers/constants.h
+++ b/src/helpers/constants.h
@@ -78,7 +78,7 @@ class Constants {
   }
 
   /// defaultDbName returns a string storing the "name" of the database for Qt identification
-  /// purposes. This _value_ should not
+  /// purposes. This _value_ should not be reused for other db connections.
   static QString defaultDbName() {
     return "evidence";
   }

--- a/src/helpers/constants.h
+++ b/src/helpers/constants.h
@@ -77,6 +77,12 @@ class Constants {
     return "source code pro";
   }
 
+  /// defaultDbName returns a string storing the "name" of the database for Qt identification
+  /// purposes. This _value_ should not
+  static QString defaultDbName() {
+    return "evidence";
+  }
+
  private:
   enum RepoField {
     owner = 0,

--- a/src/helpers/file_helpers.h
+++ b/src/helpers/file_helpers.h
@@ -3,6 +3,7 @@
 
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QIODevice>
 #include <QRandomGenerator>
 #include <QString>
@@ -104,6 +105,15 @@ class FileHelpers {
       throw FileError::mkError("Unable to read from file", path.toStdString(), file.error());
     }
     return data;
+  }
+
+  static bool moveFile(QString srcPath, QString dstPath, bool mkdirs=false) {
+    if (mkdirs) {
+      QDir().mkpath(QFileInfo(dstPath).dir().path());
+    }
+
+    QFile file(srcPath);
+    return file.rename(dstPath);
   }
 };
 

--- a/src/helpers/file_helpers.h
+++ b/src/helpers/file_helpers.h
@@ -108,6 +108,9 @@ class FileHelpers {
     return data;
   }
 
+  /// mkdirs creates the necessary folders along a given path.
+  /// equivalent to the unix mkdir -p command
+  /// specify isFile = true if the path points to a file, rather than a directory
   static bool mkdirs(const QString &path, bool isFile=false) {
     auto adjustedPath = path;
     if( isFile ) {
@@ -117,6 +120,9 @@ class FileHelpers {
     return QDir().mkpath(adjustedPath);
   }
 
+  /// moveFile simply moves a file from one path to the next. Optionally, this method can create
+  /// intermediary directories, as needed.
+  /// equivalent to the unix mv command
   static bool moveFile(QString srcPath, QString dstPath, bool mkdirs=false) {
     if (mkdirs) {
       FileHelpers::mkdirs(dstPath, true);
@@ -126,6 +132,9 @@ class FileHelpers {
     return file.rename(dstPath);
   }
 
+  /// copyFile simply copies a file from one path to the next. Optionally, this method can create
+  /// intermediary directories, as needed.
+  /// equivalent to the unix cp command
   static FileCopyResult copyFile(QString srcPath, QString dstPath, bool mkdirs=false) {
     FileCopyResult r;
     if (mkdirs) {
@@ -139,9 +148,13 @@ class FileHelpers {
     return r;
   }
 
+  /// getFilename is a small helper to convert a QFile into a filename (excluding the path)
   static QString getFilename(QFile f) { return QFileInfo(f).fileName(); }
+  /// getFilename is a small helper to convert a filepath into a filename
   static QString getFilename(QString filepath) { return QFileInfo(filepath).fileName(); }
+  /// getDirname is a small helper to convert a QFile pointing to a file into a path to that file's parent
   static QString getDirname(QFile f) { return QFileInfo(f).dir().path(); }
+  /// getDirname is a small helper to convert a filepath to a file into a path to the file's parent
   static QString getDirname(QString filepath) {
     // maybe faster: filepath.left(filepath.lastIndexOf("/"));
     return QFileInfo(filepath).dir().path();

--- a/src/helpers/file_helpers.h
+++ b/src/helpers/file_helpers.h
@@ -12,6 +12,13 @@
 
 #include "exceptions/fileerror.h"
 
+class FileCopyResult {
+ public:
+  FileCopyResult(){}
+  bool success = false;
+  QFile* file;
+};
+
 class FileHelpers {
  public:
   /// randomText generates an arbitrary number of case-sensitive english letters
@@ -119,13 +126,17 @@ class FileHelpers {
     return file.rename(dstPath);
   }
 
-  static bool copyFile(QString srcPath, QString dstPath, bool mkdirs=false) {
+  static FileCopyResult copyFile(QString srcPath, QString dstPath, bool mkdirs=false) {
+    FileCopyResult r;
     if (mkdirs) {
       FileHelpers::mkdirs(dstPath, true);
     }
 
     QFile file(srcPath);
-    return file.copy(dstPath);
+    r.file = &file;
+    r.success = file.copy(dstPath);
+
+    return r;
   }
 
   static QString getFilename(QFile f) { return QFileInfo(f).fileName(); }

--- a/src/helpers/jsonhelpers.h
+++ b/src/helpers/jsonhelpers.h
@@ -7,6 +7,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <functional>
 #include <vector>
 
 // parseJSONList parses a JSON list into a vector of concrete types from a byte[]. If any error
@@ -32,7 +33,7 @@ static std::vector<T> parseJSONList(QByteArray data, T (*dataToItem)(QJsonObject
 // parseJSONItem parses a single item (assumed to be a Json Object) from a byte[]. If any error
 // occurs during parsing, an empty object is returned.
 template <typename T>
-static T parseJSONItem(QByteArray data, T (*dataToItem)(QJsonObject)) {
+static T parseJSONItem(QByteArray data, std::function<T(QJsonObject)>dataToItem) {
   QJsonParseError err;
   QJsonDocument doc = QJsonDocument::fromJson(data, &err);
   if (err.error != QJsonParseError::NoError) {

--- a/src/helpers/screenshot.cpp
+++ b/src/helpers/screenshot.cpp
@@ -15,6 +15,7 @@
 
 #include "appconfig.h"
 #include "helpers/file_helpers.h"
+#include "helpers/system_helpers.h"
 
 Screenshot::Screenshot(QObject *parent) : QObject(parent) {}
 
@@ -33,12 +34,19 @@ void Screenshot::captureArea() { basicScreenshot(AppConfig::getInstance().screen
 
 void Screenshot::captureWindow() { basicScreenshot(AppConfig::getInstance().captureWindowExec); }
 
+QString Screenshot::mkName() {
+  return FileHelpers::randomFilename("ashirt_screenshot_XXXXXX." + extension());
+}
+QString Screenshot::contentType() { return "image"; }
+QString Screenshot::extension() { return "png"; }
+
+
 void Screenshot::basicScreenshot(QString cmdProto) {
-  auto root = FileHelpers::pathToEvidence();
+  auto root = SystemHelpers::pathToEvidence();
   auto hasPath = QDir().mkpath(root);
 
   if (hasPath) {
-    auto tempPath = FileHelpers::randomFilename(QDir::tempPath() + "/ashirt_screenshot_XXXXXX.png");
+    auto tempPath = QDir::tempPath() + "/" + mkName();
 
     QString cmd = formatScreenshotCmd(std::move(cmdProto), tempPath);
     auto lastSlash = tempPath.lastIndexOf("/") + 1;

--- a/src/helpers/screenshot.h
+++ b/src/helpers/screenshot.h
@@ -14,6 +14,10 @@ class Screenshot : public QObject {
   void captureArea();
   void captureWindow();
 
+  static QString mkName();
+  static QString extension();
+  static QString contentType();
+
  signals:
   void onScreenshotCaptured(QString filepath);
 

--- a/src/helpers/system_helpers.h
+++ b/src/helpers/system_helpers.h
@@ -1,0 +1,30 @@
+#ifndef SYSTEM_HELPERS_H
+#define SYSTEM_HELPERS_H
+
+#include <QString>
+#include <QDir>
+
+#include "appconfig.h"
+#include "appsettings.h"
+
+class SystemHelpers {
+
+ public:
+
+  /// Returns (and creates, if necessary) the path to where evidence should be stored (includes
+  /// ending path separator)
+  static QString pathToEvidence() {
+    AppConfig &conf = AppConfig::getInstance();
+    auto op = AppSettings::getInstance().operationSlug();
+    auto root = conf.evidenceRepo + "/";
+    if (op != "") {
+      root += op + "/";
+    }
+
+    QDir().mkpath(root);
+    return root;
+  }
+
+};
+
+#endif // SYSTEM_HELPERS_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) {
 
   DatabaseConnection* conn;
   try {
-    conn = new DatabaseConnection();
+    conn = new DatabaseConnection(Constants::dbLocation(), Constants::defaultDbName());
     conn->connect();
   }
   catch (FileError& err) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@ QDataStream& operator>>(QDataStream& in, model::Tag& v) {
 
 QDataStream& operator<<(QDataStream& out, const std::vector<model::Tag>& v) {
   out << int(v.size());
-  for (auto tag : v) {
+  for (const auto& tag : v) {
     out << tag;
   }
   return out;

--- a/src/models/codeblock.cpp
+++ b/src/models/codeblock.cpp
@@ -5,6 +5,7 @@
 #include <QVariant>
 #include <utility> 
 #include "helpers/file_helpers.h"
+#include "helpers/system_helpers.h"
 #include "helpers/jsonhelpers.h"
 
 static Codeblock fromJson(QJsonObject obj) {
@@ -22,11 +23,17 @@ static Codeblock fromJson(QJsonObject obj) {
 Codeblock::Codeblock() = default;
 
 Codeblock::Codeblock(QString content) {
-  this->filename =
-      FileHelpers::randomFilename(FileHelpers::pathToEvidence() + "ashirt_codeblock_XXXXXX.json");
+  this->filename = SystemHelpers::pathToEvidence() + Codeblock::mkName();
   this->content = std::move(content);
   this->subtype = "";
   this->source = "";
+}
+
+QString Codeblock::mkName() {
+  return FileHelpers::randomFilename("ashirt_codeblock_XXXXXX." + extension());
+}
+QString Codeblock::extension() {
+  return "json";
 }
 
 void Codeblock::saveCodeblock(Codeblock codeblock) {
@@ -39,6 +46,10 @@ Codeblock Codeblock::readCodeblock(const QString& filepath) {
   Codeblock rtn = parseJSONItem<Codeblock>(data, fromJson);
   rtn.filename = filepath;
   return rtn;
+}
+
+QString Codeblock::contentType() {
+  return "codeblock";
 }
 
 QByteArray Codeblock::encode() {

--- a/src/models/codeblock.h
+++ b/src/models/codeblock.h
@@ -26,6 +26,10 @@ class Codeblock {
    */
   static Codeblock readCodeblock(const QString& filepath);
 
+  static QString mkName();
+  static QString extension();
+  static QString contentType();
+
  public:
   /// content stores the actual codeblock data (i.e. the source code)
   QString content;

--- a/src/models/tag.h
+++ b/src/models/tag.h
@@ -4,9 +4,9 @@
 #ifndef MODEL_TAG_H
 #define MODEL_TAG_H
 
+#include <QDataStream>
 #include <QString>
 #include <QVariant>
-#include <QDataStream>
 
 namespace model {
 class Tag {

--- a/src/models/tag.h
+++ b/src/models/tag.h
@@ -15,6 +15,7 @@ class Tag {
   ~Tag() = default;
   Tag(const Tag &) = default;
 
+  Tag(qint64 id, qint64 evidenceID, qint64 tagId, QString name) : Tag(id, tagId, name) { this->evidenceId = evidenceID; }
   Tag(qint64 id, qint64 tagId, QString name) : Tag(tagId, name) { this->id = id; }
   Tag(qint64 tagId, QString name) {
     this->serverTagId = tagId;
@@ -25,6 +26,7 @@ class Tag {
   qint64 id;
   qint64 serverTagId;
   QString tagName;
+  qint64 evidenceId;
 };
 }  // namespace model
 

--- a/src/porting/evidence_manifest.h
+++ b/src/porting/evidence_manifest.h
@@ -10,7 +10,7 @@
 #include "helpers/jsonhelpers.h"
 #include "helpers/file_helpers.h"
 
-namespace sync {
+namespace porting {
 
 class EvidenceItem {
  public:

--- a/src/porting/evidence_manifest.h
+++ b/src/porting/evidence_manifest.h
@@ -1,0 +1,62 @@
+#ifndef SYNC_EVIDENCE_MANIFEST_H
+#define SYNC_EVIDENCE_MANIFEST_H
+
+#include <QString>
+#include <QJsonArray>
+#include <QJsonObject>
+
+#include <vector>
+
+#include "helpers/jsonhelpers.h"
+#include "helpers/file_helpers.h"
+
+namespace sync {
+
+class EvidenceItem {
+ public:
+  EvidenceItem(){}
+  EvidenceItem(qint64 id, QString path) {
+    this->evidenceID = id;
+    this->exportPath = path;
+  }
+
+ public:
+  static QJsonObject serialize(EvidenceItem item) {
+    QJsonObject o;
+    o.insert("evidenceID", item.evidenceID);
+    o.insert("path", item.exportPath);
+    return o;
+  }
+  static EvidenceItem deserialize(QJsonObject o) {
+    return EvidenceItem(o.value("evidenceID").toInt(), o.value("path").toString());
+  }
+
+ public:
+  qint64 evidenceID = 0;
+  QString exportPath = "";
+};
+
+class EvidenceManifest {
+ public:
+  static QJsonArray serialize(EvidenceManifest manifest) {
+    QJsonArray a;
+    for (EvidenceItem evi : manifest.entries) {
+      a.append(EvidenceItem::serialize(evi));
+    }
+    return a;
+  }
+
+  static EvidenceManifest deserialize(QString filepath) {
+    EvidenceManifest manifest;
+    manifest.entries = parseJSONList<EvidenceItem>(
+        FileHelpers::readFile(filepath), &EvidenceItem::deserialize);
+    return manifest;
+  }
+
+ public:
+  std::vector<EvidenceItem> entries;
+};
+
+}
+
+#endif // SYNC_EVIDENCE_MANIFEST_H

--- a/src/porting/evidence_manifest.h
+++ b/src/porting/evidence_manifest.h
@@ -12,6 +12,10 @@
 
 namespace porting {
 
+/**
+ * @brief The EvidenceItem class is a simple object that records information about an exported
+ * evidence item. It also knows how to encode and decode itself for exporting/importing purposes
+ */
 class EvidenceItem {
  public:
   EvidenceItem(){}
@@ -36,6 +40,10 @@ class EvidenceItem {
   QString exportPath = "";
 };
 
+/**
+ * @brief The EvidenceManifest class is simply a wrapper around a collection of EvidenceItems. It
+ * also provides a mechanism to encode and decode itself for exporting/importing purposes
+ */
 class EvidenceManifest {
  public:
   static QJsonArray serialize(EvidenceManifest manifest) {

--- a/src/porting/system_manifest.cpp
+++ b/src/porting/system_manifest.cpp
@@ -1,0 +1,180 @@
+#include "system_manifest.h"
+
+using namespace sync;
+
+void SystemManifest::applyManifest(SystemManifestImportOptions options, DatabaseConnection* systemDb) {
+  bool shouldMigrateConfig = options.importConfig && !configPath.isEmpty();
+  bool shouldMigrateDb = options.importDb == SystemManifestImportOptions::Merge && !dbPath.isEmpty();
+
+  if (shouldMigrateConfig) {
+    migrateConfig();
+  }
+
+  if (shouldMigrateDb) {
+    migrateDb(systemDb);
+  }
+}
+
+void SystemManifest::migrateConfig() {
+  auto data = FileHelpers::readFile(pathToFile(configPath));
+  parseJSONItem<QString>(data, [](QJsonObject src) {
+    for(QString key : src.keys()) {
+      src.remove("evidenceRepo"); // removing evidenceRepo, as we never want to replace what the user has set there.
+
+      // only opting to migrate connection settings, given that translating other options may
+      // cause problems (especially if migrating between oses)
+      if (key != "accessKey" && key != "secretKey" && key != "apiURL") {
+        src.remove(key);
+      }
+    }
+    AppConfig::getInstance().applyConfig(src);
+    return "";
+  });
+  AppConfig::getInstance().writeConfig(); // save updated config
+}
+
+void SystemManifest::migrateDb(DatabaseConnection* systemDb) {
+  auto evidenceManifest = EvidenceManifest::deserialize(pathToFile(evidenceManifestPath));
+  DatabaseConnection::withConnection(
+      pathToFile(dbPath), "importDb", [this, evidenceManifest, systemDb](DatabaseConnection importDb) {
+        // migrate evidence (make new file, copy content, create db entry)
+        for (auto item : evidenceManifest.entries) {
+          auto importRecord = importDb.getEvidenceDetails(item.evidenceID);
+          if (importRecord.id == 0) {
+            continue; // in the odd situation that evidence doesn't match up, just skip it
+          }
+          QString newEvidencePath = AppConfig::getInstance().evidenceRepo + "/" +
+                                    importRecord.operationSlug + "/" +
+                                    contentSensitiveFilename(importRecord.contentType);
+          QString newEviPathLastFour = newEvidencePath.right(4);
+
+          auto fullFileExportPath = pathToManifest + "/" + item.exportPath;
+          auto success = FileHelpers::copyFile(fullFileExportPath, newEvidencePath, true);
+          importRecord.path = newEvidencePath;
+          qint64 evidenceID = systemDb->createFullEvidence(importRecord);
+          systemDb->setEvidenceTags(importRecord.tags, evidenceID);
+       }
+  });
+}
+
+QString SystemManifest::pathToFile(QString filename) {
+  return pathToManifest + "/" + filename;
+}
+
+QString SystemManifest::contentSensitiveExtension(QString contentType) {
+  if (contentType == Codeblock::contentType()) {
+    return Codeblock::extension();
+  }
+  else if(contentType == Screenshot::contentType()) {
+    return Screenshot::extension();
+  }
+  else {
+    return ".bin";
+  }
+}
+
+QString SystemManifest::contentSensitiveFilename(QString contentType) {
+  if (contentType == Codeblock::contentType()) {
+    return Codeblock::mkName();
+  }
+  else if(contentType == Screenshot::contentType()) {
+    return Screenshot::mkName();
+  }
+  else {
+    return FileHelpers::randomFilename("ashirt_unknown_type_XXXXXX.bin");
+  }
+}
+
+SystemManifest SystemManifest::readManifest(QString pathToExportFile) {
+  auto content = FileHelpers::readFile(pathToExportFile);
+  SystemManifest manifest = parseJSONItem<SystemManifest>(content, &SystemManifest::deserialize);
+  manifest.pathToManifest = FileHelpers::getDirname(pathToExportFile);
+
+  return manifest;
+}
+
+void SystemManifest::exportManifest(DatabaseConnection* db, QString outputDirPath, const SystemManifestExportOptions& options) {
+  if (!options.includesAnything()) {
+    return;
+  }
+
+  bool success = FileHelpers::mkdirs(outputDirPath);
+  if (!success) {
+    return;
+  }
+
+  os = QSysInfo::kernelType(); // may need to check possible answers, or maybe just compare to new system value?
+
+  QString basePath = QDir(outputDirPath).path();
+
+  if (options.exportConfig) {
+    configPath = "config.json";
+    AppConfig::getInstance().writeConfig(basePath + "/" + configPath);
+  }
+
+  if (options.exportDb) {
+    dbPath = "db.sqlite";
+    evidenceManifestPath = "evidence.json";
+
+    auto allEvidence = DatabaseConnection::createEvidenceExportView(basePath + "/" + dbPath, EvidenceFilters(), db);
+
+    // Copy evidence content
+    //        QString evidenceBase = "evidence";
+    //        FileHelpers::mkdirs(basePath + "/" + evidenceBase);
+
+    //        sync::EvidenceManifest evidenceManifest;
+    //        for (auto evi : allEvidence) {
+    //          QString newName = FileHelpers::randomFilename("ashirt_evidence_??????????." + contentSensitiveExtension(evi.contentType), "??????????");
+    //          auto item = sync::EvidenceItem(evi.id, evidenceBase + "/" + newName);
+    //          FileHelpers::copyFile(evi.path, basePath + "/" + item.exportPath);
+    //          evidenceManifest.entries.push_back(item);
+    //        }
+    sync::EvidenceManifest evidenceManifest = copyEvidence(basePath, allEvidence);
+
+    // write evidence manifest
+    FileHelpers::writeFile(basePath + "/" + evidenceManifestPath,
+                           QJsonDocument(EvidenceManifest::serialize(evidenceManifest)).toJson());
+  }
+
+  QString exportPath = basePath + "/system.json";
+  this->pathToManifest = exportPath;
+  FileHelpers::writeFile(exportPath, QJsonDocument(serialize(*this)).toJson());
+}
+
+
+sync::EvidenceManifest SystemManifest::copyEvidence(QString baseExportPath, std::vector<model::Evidence> allEvidence) {
+  QString relativeEvidenceDir = "evidence";
+  FileHelpers::mkdirs(baseExportPath + "/" + relativeEvidenceDir);
+
+  sync::EvidenceManifest evidenceManifest;
+  for (auto evi : allEvidence) {
+    QString randPart = "??????????";
+    QString filenameTemplate = QString("ashirt_evidence_$1.$2").arg(randPart).arg(contentSensitiveExtension(evi.contentType));
+    QString newName = FileHelpers::randomFilename(filenameTemplate, randPart);
+    auto item = sync::EvidenceItem(evi.id, relativeEvidenceDir + "/" + newName);
+    FileHelpers::copyFile(evi.path, baseExportPath + "/" + item.exportPath);
+    evidenceManifest.entries.push_back(item);
+  }
+  return evidenceManifest;
+}
+
+
+QJsonObject SystemManifest::serialize(const SystemManifest& src) {
+  QJsonObject o;
+  o.insert("operatingSystem", src.os);
+  o.insert("databasePath", src.dbPath);
+  o.insert("configPath", src.configPath);
+  o.insert("serversPath", src.serversPath);
+  o.insert("evidenceManifestPath", src.evidenceManifestPath);
+  return o;
+}
+
+SystemManifest SystemManifest::deserialize(QJsonObject o) {
+  SystemManifest manifest;
+  manifest.os = o.value("operatingSystem").toString();
+  manifest.dbPath = o.value("databasePath").toString();
+  manifest.configPath = o.value("configPath").toString();
+  manifest.serversPath = o.value("serversPath").toString();
+  manifest.evidenceManifestPath = o.value("evidenceManifestPath").toString();
+  return manifest;
+}

--- a/src/porting/system_manifest.cpp
+++ b/src/porting/system_manifest.cpp
@@ -166,8 +166,9 @@ porting::EvidenceManifest SystemManifest::copyEvidence(QString baseExportPath, s
       emit onCopyFileError(evi.path, dstPath,
                            FileError::mkError(copyResult.file->errorString(), dstPath, copyResult.file->error()));
     }
-
-    evidenceManifest.entries.push_back(item);
+    else {
+      evidenceManifest.entries.push_back(item);
+    }
     emit onFileProcessed(evidenceIndex + 1);
   }
   return evidenceManifest;

--- a/src/porting/system_manifest.cpp
+++ b/src/porting/system_manifest.cpp
@@ -1,6 +1,6 @@
 #include "system_manifest.h"
 
-using namespace sync;
+using namespace porting;
 
 void SystemManifest::applyManifest(SystemManifestImportOptions options, DatabaseConnection* systemDb) {
   bool shouldMigrateConfig = options.importConfig && !configPath.isEmpty();
@@ -133,7 +133,7 @@ void SystemManifest::exportManifest(DatabaseConnection* db, QString outputDirPat
 
     auto allEvidence = DatabaseConnection::createEvidenceExportView(basePath + "/" + dbPath, EvidenceFilters(), db);
     emit onReady(allEvidence.size());
-    sync::EvidenceManifest evidenceManifest = copyEvidence(basePath, allEvidence);
+    porting::EvidenceManifest evidenceManifest = copyEvidence(basePath, allEvidence);
 
     // write evidence manifest
     FileHelpers::writeFile(basePath + "/" + evidenceManifestPath,
@@ -146,11 +146,11 @@ void SystemManifest::exportManifest(DatabaseConnection* db, QString outputDirPat
   emit onComplete();
 }
 
-sync::EvidenceManifest SystemManifest::copyEvidence(QString baseExportPath, std::vector<model::Evidence> allEvidence) {
+porting::EvidenceManifest SystemManifest::copyEvidence(QString baseExportPath, std::vector<model::Evidence> allEvidence) {
   QString relativeEvidenceDir = "evidence";
   FileHelpers::mkdirs(baseExportPath + "/" + relativeEvidenceDir);
 
-  sync::EvidenceManifest evidenceManifest;
+  porting::EvidenceManifest evidenceManifest;
   for (size_t evidenceIndex = 0; evidenceIndex < allEvidence.size(); evidenceIndex++) {
     auto evi = allEvidence.at(evidenceIndex);
     QString randPart = "??????????";
@@ -158,7 +158,7 @@ sync::EvidenceManifest SystemManifest::copyEvidence(QString baseExportPath, std:
                                 .arg(randPart)
                                 .arg(contentSensitiveExtension(evi.contentType));
     QString newName = FileHelpers::randomFilename(filenameTemplate, randPart);
-    auto item = sync::EvidenceItem(evi.id, relativeEvidenceDir + "/" + newName);
+    auto item = porting::EvidenceItem(evi.id, relativeEvidenceDir + "/" + newName);
     auto dstPath = baseExportPath + "/" + item.exportPath;
     auto copyResult = FileHelpers::copyFile(evi.path, dstPath);
 

--- a/src/porting/system_manifest.cpp
+++ b/src/porting/system_manifest.cpp
@@ -20,7 +20,7 @@ void SystemManifest::applyManifest(SystemManifestImportOptions options, Database
 void SystemManifest::migrateConfig() {
   auto data = FileHelpers::readFile(pathToFile(configPath));
   parseJSONItem<QString>(data, [](QJsonObject src) {
-    for(QString key : src.keys()) {
+    for(const QString& key : src.keys()) {
       src.remove("evidenceRepo"); // removing evidenceRepo, as we never want to replace what the user has set there.
 
       // only opting to migrate connection settings, given that translating other options may
@@ -70,35 +70,31 @@ void SystemManifest::migrateDb(DatabaseConnection* systemDb) {
   });
 }
 
-QString SystemManifest::pathToFile(QString filename) {
+QString SystemManifest::pathToFile(const QString& filename) {
   return pathToManifest + "/" + filename;
 }
 
-QString SystemManifest::contentSensitiveExtension(QString contentType) {
+QString SystemManifest::contentSensitiveExtension(const QString& contentType) {
   if (contentType == Codeblock::contentType()) {
     return Codeblock::extension();
   }
   else if(contentType == Screenshot::contentType()) {
     return Screenshot::extension();
   }
-  else {
-    return ".bin";
-  }
+  return ".bin";
 }
 
-QString SystemManifest::contentSensitiveFilename(QString contentType) {
+QString SystemManifest::contentSensitiveFilename(const QString& contentType) {
   if (contentType == Codeblock::contentType()) {
     return Codeblock::mkName();
   }
   else if(contentType == Screenshot::contentType()) {
     return Screenshot::mkName();
   }
-  else {
-    return FileHelpers::randomFilename("ashirt_unknown_type_XXXXXX.bin");
-  }
+  return FileHelpers::randomFilename("ashirt_unknown_type_XXXXXX.bin");
 }
 
-SystemManifest* SystemManifest::readManifest(QString pathToExportFile) {
+SystemManifest* SystemManifest::readManifest(const QString& pathToExportFile) {
   auto content = FileHelpers::readFile(pathToExportFile);
   auto manifest = parseJSONItem<SystemManifest*>(content, &SystemManifest::deserialize);
   manifest->pathToManifest = FileHelpers::getDirname(pathToExportFile);
@@ -106,7 +102,8 @@ SystemManifest* SystemManifest::readManifest(QString pathToExportFile) {
   return manifest;
 }
 
-void SystemManifest::exportManifest(DatabaseConnection* db, QString outputDirPath, const SystemManifestExportOptions& options) {
+void SystemManifest::exportManifest(DatabaseConnection* db, const QString& outputDirPath,
+                                    const SystemManifestExportOptions& options) {
   if (!options.includesAnything()) {
     return;
   }
@@ -146,7 +143,8 @@ void SystemManifest::exportManifest(DatabaseConnection* db, QString outputDirPat
   emit onComplete();
 }
 
-porting::EvidenceManifest SystemManifest::copyEvidence(QString baseExportPath, std::vector<model::Evidence> allEvidence) {
+porting::EvidenceManifest SystemManifest::copyEvidence(const QString& baseExportPath,
+                                                       std::vector<model::Evidence> allEvidence) {
   QString relativeEvidenceDir = "evidence";
   FileHelpers::mkdirs(baseExportPath + "/" + relativeEvidenceDir);
 
@@ -155,8 +153,7 @@ porting::EvidenceManifest SystemManifest::copyEvidence(QString baseExportPath, s
     auto evi = allEvidence.at(evidenceIndex);
     QString randPart = "??????????";
     auto filenameTemplate = QString("ashirt_evidence_%1.%2")
-                                .arg(randPart)
-                                .arg(contentSensitiveExtension(evi.contentType));
+                                .arg(randPart, contentSensitiveExtension(evi.contentType));
     QString newName = FileHelpers::randomFilename(filenameTemplate, randPart);
     auto item = porting::EvidenceItem(evi.id, relativeEvidenceDir + "/" + newName);
     auto dstPath = baseExportPath + "/" + item.exportPath;
@@ -184,7 +181,7 @@ QJsonObject SystemManifest::serialize(const SystemManifest& src) {
   return o;
 }
 
-SystemManifest* SystemManifest::deserialize(QJsonObject o) {
+SystemManifest* SystemManifest::deserialize(const QJsonObject& o) {
   auto manifest = new SystemManifest;
   manifest->os = o.value("operatingSystem").toString();
   manifest->dbPath = o.value("databasePath").toString();

--- a/src/porting/system_manifest.cpp
+++ b/src/porting/system_manifest.cpp
@@ -117,18 +117,6 @@ void SystemManifest::exportManifest(DatabaseConnection* db, QString outputDirPat
     evidenceManifestPath = "evidence.json";
 
     auto allEvidence = DatabaseConnection::createEvidenceExportView(basePath + "/" + dbPath, EvidenceFilters(), db);
-
-    // Copy evidence content
-    //        QString evidenceBase = "evidence";
-    //        FileHelpers::mkdirs(basePath + "/" + evidenceBase);
-
-    //        sync::EvidenceManifest evidenceManifest;
-    //        for (auto evi : allEvidence) {
-    //          QString newName = FileHelpers::randomFilename("ashirt_evidence_??????????." + contentSensitiveExtension(evi.contentType), "??????????");
-    //          auto item = sync::EvidenceItem(evi.id, evidenceBase + "/" + newName);
-    //          FileHelpers::copyFile(evi.path, basePath + "/" + item.exportPath);
-    //          evidenceManifest.entries.push_back(item);
-    //        }
     sync::EvidenceManifest evidenceManifest = copyEvidence(basePath, allEvidence);
 
     // write evidence manifest
@@ -141,7 +129,6 @@ void SystemManifest::exportManifest(DatabaseConnection* db, QString outputDirPat
   FileHelpers::writeFile(exportPath, QJsonDocument(serialize(*this)).toJson());
 }
 
-
 sync::EvidenceManifest SystemManifest::copyEvidence(QString baseExportPath, std::vector<model::Evidence> allEvidence) {
   QString relativeEvidenceDir = "evidence";
   FileHelpers::mkdirs(baseExportPath + "/" + relativeEvidenceDir);
@@ -149,7 +136,7 @@ sync::EvidenceManifest SystemManifest::copyEvidence(QString baseExportPath, std:
   sync::EvidenceManifest evidenceManifest;
   for (auto evi : allEvidence) {
     QString randPart = "??????????";
-    QString filenameTemplate = QString("ashirt_evidence_$1.$2").arg(randPart).arg(contentSensitiveExtension(evi.contentType));
+    QString filenameTemplate = QString("ashirt_evidence_%1.%2").arg(randPart).arg(contentSensitiveExtension(evi.contentType));
     QString newName = FileHelpers::randomFilename(filenameTemplate, randPart);
     auto item = sync::EvidenceItem(evi.id, relativeEvidenceDir + "/" + newName);
     FileHelpers::copyFile(evi.path, baseExportPath + "/" + item.exportPath);
@@ -157,7 +144,6 @@ sync::EvidenceManifest SystemManifest::copyEvidence(QString baseExportPath, std:
   }
   return evidenceManifest;
 }
-
 
 QJsonObject SystemManifest::serialize(const SystemManifest& src) {
   QJsonObject o;

--- a/src/porting/system_manifest.h
+++ b/src/porting/system_manifest.h
@@ -23,7 +23,7 @@ class SystemManifest : public QObject {
   Q_OBJECT;
 
  public:
-  SystemManifest(){}
+  SystemManifest() {}
   ~SystemManifest(){}
 
   /**
@@ -32,7 +32,7 @@ class SystemManifest : public QObject {
    * @return the completed SystemManifest
    * @throws FileError if there is an issue reading the file at the indicated path
    */
-  static SystemManifest* readManifest(QString pathToExportFile);
+  static SystemManifest* readManifest(const QString& pathToExportFile);
 
  public:
  signals:
@@ -52,19 +52,20 @@ class SystemManifest : public QObject {
   static QJsonObject serialize(const SystemManifest& src);
 
   /// deserialize converts a json object into a system manifest instance
-  static SystemManifest* deserialize(QJsonObject o);
+  static SystemManifest* deserialize(const QJsonObject& o);
 
  private:
-  /// contentSensitiveFilename returns a (random) filename for the given content type. This, in turn,
-  /// relies on the underlying type to provide a sensible value. If no match is found, then
-  /// "ashirt_unknown_type_XXXXXX.bin" (X's will be replaced with random characters) is returned instead.
+  /// contentSensitiveFilename returns a (random) filename for the given content type. This, in
+  /// turn, relies on the underlying type to provide a sensible value. If no match is found, then
+  /// "ashirt_unknown_type_XXXXXX.bin" (X's will be replaced with random characters) is returned
+  /// instead.
   /// @see FileHelpers::randomFilename
-  static QString contentSensitiveFilename(QString contentType);
+  static QString contentSensitiveFilename(const QString& contentType);
 
   /// contentSensitiveExtension returns a file extension for the given content type. This, in turn,
   /// relies on the underlying type to provide a sensible value. If no match is found, then ".bin"
   /// is returned instead
-  static QString contentSensitiveExtension(QString contentType);
+  static QString contentSensitiveExtension(const QString& contentType);
 
  public:
   /**
@@ -85,8 +86,8 @@ class SystemManifest : public QObject {
    * @throws FileError if there is a problem with the given directory, or with a generated filename
    * @throws QSqlError if there is an issue accessing the system database, or the copied database
    */
-  void exportManifest(DatabaseConnection* db, QString outputDirPath, const SystemManifestExportOptions& options);
-
+  void exportManifest(DatabaseConnection* db, const QString& outputDirPath,
+                      const SystemManifestExportOptions& options);
 
  private:
   /**
@@ -106,7 +107,7 @@ class SystemManifest : public QObject {
 
   /// pathToFile is a small helper method to combine the absolute path to the manifest with the relative
   /// path to the given filename. The result is an absolute path to the given file
-  QString pathToFile(QString filename);
+  QString pathToFile(const QString& filename);
 
   /**
    * @brief copyEvidence will iteratively copy all evidence files provided to the indicated path. Files are renamed
@@ -117,8 +118,8 @@ class SystemManifest : public QObject {
    * @param allEvidence a vector of evidence _data_ to export (files will be found and read from within this function)
    * @return an EvidenceManifest listing all of the files copied, and their new names.
    */
-  porting::EvidenceManifest copyEvidence(QString baseExportPath, std::vector<model::Evidence> allEvidence);
-
+  porting::EvidenceManifest copyEvidence(const QString& baseExportPath,
+                                         std::vector<model::Evidence> allEvidence);
 
  public:
   /// os is the operating system associated with the originating export

--- a/src/porting/system_manifest.h
+++ b/src/porting/system_manifest.h
@@ -17,7 +17,7 @@
 
 #include "system_porting_options.h"
 
-namespace sync {
+namespace porting {
 
 class SystemManifest : public QObject {
   Q_OBJECT;
@@ -102,7 +102,7 @@ class SystemManifest : public QObject {
    * @throws QSqlError
    * @return
    */
-  sync::EvidenceManifest copyEvidence(QString baseExportPath, std::vector<model::Evidence> allEvidence);
+  porting::EvidenceManifest copyEvidence(QString baseExportPath, std::vector<model::Evidence> allEvidence);
 
 
  public:

--- a/src/porting/system_manifest.h
+++ b/src/porting/system_manifest.h
@@ -1,0 +1,227 @@
+#ifndef SYNC_SYSTEM_MANIFEST_H
+#define SYNC_SYSTEM_MANIFEST_H
+
+#include <QString>
+#include <QFile>
+#include <QJsonObject>
+
+#include "helpers/file_helpers.h"
+#include "helpers/jsonhelpers.h"
+#include "helpers/screenshot.h"
+#include "appconfig.h"
+#include "appsettings.h"
+#include "db/databaseconnection.h"
+#include "evidence_manifest.h"
+#include "models/codeblock.h"
+
+#include "system_porting_options.h"
+
+namespace sync {
+
+class SystemManifest {
+
+ public:
+  static SystemManifest buildManifest(DatabaseConnection* db, QString outputDirPath, const SystemManifestExportOptions& options) {
+    auto rtn = SystemManifest();
+    if (!options.includesAnything()) {
+      return rtn;
+    }
+
+    bool success = FileHelpers::mkdirs(outputDirPath);
+    if (!success) {
+      return rtn;
+    }
+
+    rtn.os = QSysInfo::kernelType(); // may need to check possible answers, or maybe just compare to new system value?
+
+    QString basePath = QDir(outputDirPath).path();
+    try {
+      // copy config
+      if (options.exportConfig) {
+        rtn.configPath = "config.json";
+        QString cfgPath = basePath + "/" + rtn.configPath;
+        AppConfig::getInstance().writeConfig(cfgPath);
+      }
+
+      // copy database
+      if (options.exportDb) {
+        rtn.dbPath = "db.sqlite";
+        QString dbPath = basePath + "/" + rtn.dbPath;
+
+        // FileHelpers::copyFile(Constants::dbLocation(), dbPath);  // faster copy, no fine tuning
+
+        // slower copy, abilty to select specific details
+        auto allEvidence = DatabaseConnection::createEvidenceExportView(dbPath, EvidenceFilters(), db);
+
+        // Copy evidence content
+        QString evidenceBase = "evidence";
+        FileHelpers::mkdirs(basePath + "/" + evidenceBase);
+
+        sync::EvidenceManifest evidenceManifest;
+        for (auto evi : allEvidence) {
+          QString newName = FileHelpers::randomFilename("ashirt_evidence_??????????." + contentSensitiveExtension(evi.contentType), "??????????");
+          auto item = sync::EvidenceItem(evi.id, evidenceBase + "/" + newName);
+          FileHelpers::copyFile(evi.path, basePath + "/" + item.exportPath);
+          evidenceManifest.entries.push_back(item);
+        }
+
+        // write evidence manifest
+        rtn.evidenceManifestPath = "evidence.json";
+        QString evidenceManifestPath = basePath + "/" + rtn.evidenceManifestPath;
+        FileHelpers::writeFile(evidenceManifestPath, QJsonDocument(EvidenceManifest::serialize(evidenceManifest)).toJson());
+      }
+
+      QString exportPath = basePath + "/system.json";
+      rtn.pathToManifest = exportPath;
+      FileHelpers::writeFile( exportPath, QJsonDocument(serialize(rtn)).toJson() );
+    }
+    catch (const FileError &e) {
+      std::cerr << "File error doing buildManifest: " << e.what() << std::endl;
+    }
+    catch (const QSqlError &e) {
+      std::cerr << "SQL error doing buildManifest: " << e.text().toStdString() << std::endl;
+    }
+
+
+    return rtn;
+  }
+
+  static SystemManifest readManifest(QString pathToExportFile) {
+    SystemManifest manifest;
+
+    try {
+      auto content = FileHelpers::readFile(pathToExportFile);
+      manifest = parseJSONItem<SystemManifest>(content, &SystemManifest::deserialize);
+      manifest.pathToManifest = FileHelpers::getDirname(pathToExportFile);
+    }
+    catch (const FileError& e) {
+      std::cout << "Got an exception: " << e.what() << std::endl;
+    }
+
+    return manifest;
+  }
+
+  static QString contentSensitiveFilename(QString contentType) {
+    if (contentType == Codeblock::contentType()) {
+      return Codeblock::mkName();
+    }
+    else if(contentType == Screenshot::contentType()) {
+      return Screenshot::mkName();
+    }
+    else {
+      return FileHelpers::randomFilename("ashirt_unknown_type.bin");
+    }
+  }
+
+  static QString contentSensitiveExtension(QString contentType) {
+    if (contentType == Codeblock::contentType()) {
+      return Codeblock::extension();
+    }
+    else if(contentType == Screenshot::contentType()) {
+      return Screenshot::extension();
+    }
+    else {
+      return FileHelpers::randomFilename("bin");
+    }
+  }
+
+  static QJsonObject serialize(SystemManifest src) {
+    QJsonObject o;
+    o.insert("operatingSystem", src.os);
+    o.insert("databasePath", src.dbPath);
+    o.insert("configPath", src.configPath);
+    o.insert("serversPath", src.serversPath);
+    o.insert("evidenceManifestPath", src.evidenceManifestPath);
+    return o;
+  }
+
+  static SystemManifest deserialize(QJsonObject o) {
+    SystemManifest manifest;
+    manifest.os = o.value("operatingSystem").toString();
+    manifest.dbPath = o.value("databasePath").toString();
+    manifest.configPath = o.value("configPath").toString();
+    manifest.serversPath = o.value("serversPath").toString();
+    manifest.evidenceManifestPath = o.value("evidenceManifestPath").toString();
+    return manifest;
+  }
+
+ public:
+  void applyManifest(SystemManifestImportOptions options, DatabaseConnection* systemDb) {
+    bool shouldMigrateConfig = options.importConfig && !configPath.isEmpty();
+    bool shouldMigrateDb = options.importDb == SystemManifestImportOptions::Merge && !dbPath.isEmpty();
+
+    try {
+      if (shouldMigrateConfig) {
+        migrateConfig();
+      }
+
+      if (shouldMigrateDb) {
+        migrateDb(systemDb);
+      }
+    }
+    catch (const FileError& e) {
+      std::cout << "Got an exception: " << e.what() << std::endl;
+    }
+  }
+
+
+ private:
+  void migrateConfig() {
+    auto data = FileHelpers::readFile(pathToFile(configPath));
+    parseJSONItem<QString>(data, [](QJsonObject src) {
+      for(QString key : src.keys()) {
+        src.remove("evidenceRepo"); // removing evidenceRepo, as we never want to replace what the user has set there.
+
+        // only opting to migrate connection settings, given that translating other options may
+        // cause problems (especially if migrating between oses)
+        if (key != "accessKey" && key != "secretKey" && key != "apiURL") {
+          src.remove(key);
+        }
+      }
+      AppConfig::getInstance().applyConfig(src);
+      return "";
+    });
+    AppConfig::getInstance().writeConfig(); // save updated config
+  }
+
+  void migrateDb(DatabaseConnection* systemDb) {
+    auto evidenceManifest = EvidenceManifest::deserialize(pathToFile(evidenceManifestPath));
+    DatabaseConnection::withConnection(pathToFile(dbPath), "importDb",
+                                       [this, evidenceManifest, systemDb](DatabaseConnection importDb) {
+      // migrate evidence (make new file, copy content, create db entry)
+      for (auto item : evidenceManifest.entries) {
+        auto importRecord = importDb.getEvidenceDetails(item.evidenceID);
+        if (importRecord.id == 0) {
+          continue; // in the odd situation that evidence doesn't match up, just skip it
+        }
+        QString newEvidencePath = AppConfig::getInstance().evidenceRepo + "/" +
+                                  importRecord.operationSlug + "/" +
+                                  contentSensitiveFilename(importRecord.contentType);
+        QString newEviPathLastFour = newEvidencePath.right(4);
+
+        auto fullFileExportPath = pathToManifest + "/" + item.exportPath;
+        auto success = FileHelpers::copyFile(fullFileExportPath, newEvidencePath, true);
+        importRecord.path = newEvidencePath;
+        qint64 evidenceID = systemDb->createFullEvidence(importRecord);
+        systemDb->setEvidenceTags(importRecord.tags, evidenceID);
+      }
+    });
+  }
+
+  QString pathToFile(QString filename) { return pathToManifest + "/" + filename; }
+
+
+ public:
+  QString os = "";
+  QString dbPath = "";
+  QString configPath = "";
+  QString serversPath = "";
+  QString evidenceManifestPath = "";
+
+ private:
+  QString pathToManifest = "";
+};
+}
+
+#endif // SYNC_SYSTEM_MANIFEST_H
+

--- a/src/porting/system_manifest.h
+++ b/src/porting/system_manifest.h
@@ -1,9 +1,10 @@
 #ifndef SYNC_SYSTEM_MANIFEST_H
 #define SYNC_SYSTEM_MANIFEST_H
 
-#include <QString>
 #include <QFile>
 #include <QJsonObject>
+#include <QObject>
+#include <QString>
 
 #include "helpers/file_helpers.h"
 #include "helpers/jsonhelpers.h"
@@ -18,22 +19,33 @@
 
 namespace sync {
 
-class SystemManifest {
+class SystemManifest : public QObject {
+  Q_OBJECT;
 
  public:
-  SystemManifest() {}
+  SystemManifest(){}
+  ~SystemManifest(){}
 
   /**
    * @brief readManifest parses the the system.json (as provided by the caller) into a complete SystemManifest
    * @param pathToExportFile the location of the system.json file
    * @return the completed SystemManifest
+   * @throws FileError if there is an issue reading the file at the indicated path
    */
-  static SystemManifest readManifest(QString pathToExportFile);
+  static SystemManifest* readManifest(QString pathToExportFile);
+
+ public:
+ signals:
+  void onReady(quint64 numFilesToProcess);
+  void onFileProcessed(quint64 runningCount);
+  void onComplete();
+  void onCopyFileError(QString srcPath, QString dstPath, const FileError& e);
+  void onStatusUpdate(QString text);
 
  public:
   static QJsonObject serialize(const SystemManifest& src);
 
-  static SystemManifest deserialize(QJsonObject o);
+  static SystemManifest* deserialize(QJsonObject o);
 
  private:
   /// contentSensitiveFilename returns a (random) filename for the given content type. This, in turn,
@@ -46,8 +58,6 @@ class SystemManifest {
   /// relies on the underlying type to provide a sensible value. If no match is found, then ".bin"
   /// is returned instead
   static QString contentSensitiveExtension(QString contentType);
-
-
 
  public:
   /**

--- a/src/porting/system_manifest.h
+++ b/src/porting/system_manifest.h
@@ -21,194 +21,78 @@ namespace sync {
 class SystemManifest {
 
  public:
-  static SystemManifest buildManifest(DatabaseConnection* db, QString outputDirPath, const SystemManifestExportOptions& options) {
-    auto rtn = SystemManifest();
-    if (!options.includesAnything()) {
-      return rtn;
-    }
+  SystemManifest() {}
 
-    bool success = FileHelpers::mkdirs(outputDirPath);
-    if (!success) {
-      return rtn;
-    }
-
-    rtn.os = QSysInfo::kernelType(); // may need to check possible answers, or maybe just compare to new system value?
-
-    QString basePath = QDir(outputDirPath).path();
-    try {
-      // copy config
-      if (options.exportConfig) {
-        rtn.configPath = "config.json";
-        QString cfgPath = basePath + "/" + rtn.configPath;
-        AppConfig::getInstance().writeConfig(cfgPath);
-      }
-
-      // copy database
-      if (options.exportDb) {
-        rtn.dbPath = "db.sqlite";
-        QString dbPath = basePath + "/" + rtn.dbPath;
-
-        // FileHelpers::copyFile(Constants::dbLocation(), dbPath);  // faster copy, no fine tuning
-
-        // slower copy, abilty to select specific details
-        auto allEvidence = DatabaseConnection::createEvidenceExportView(dbPath, EvidenceFilters(), db);
-
-        // Copy evidence content
-        QString evidenceBase = "evidence";
-        FileHelpers::mkdirs(basePath + "/" + evidenceBase);
-
-        sync::EvidenceManifest evidenceManifest;
-        for (auto evi : allEvidence) {
-          QString newName = FileHelpers::randomFilename("ashirt_evidence_??????????." + contentSensitiveExtension(evi.contentType), "??????????");
-          auto item = sync::EvidenceItem(evi.id, evidenceBase + "/" + newName);
-          FileHelpers::copyFile(evi.path, basePath + "/" + item.exportPath);
-          evidenceManifest.entries.push_back(item);
-        }
-
-        // write evidence manifest
-        rtn.evidenceManifestPath = "evidence.json";
-        QString evidenceManifestPath = basePath + "/" + rtn.evidenceManifestPath;
-        FileHelpers::writeFile(evidenceManifestPath, QJsonDocument(EvidenceManifest::serialize(evidenceManifest)).toJson());
-      }
-
-      QString exportPath = basePath + "/system.json";
-      rtn.pathToManifest = exportPath;
-      FileHelpers::writeFile( exportPath, QJsonDocument(serialize(rtn)).toJson() );
-    }
-    catch (const FileError &e) {
-      std::cerr << "File error doing buildManifest: " << e.what() << std::endl;
-    }
-    catch (const QSqlError &e) {
-      std::cerr << "SQL error doing buildManifest: " << e.text().toStdString() << std::endl;
-    }
-
-
-    return rtn;
-  }
-
-  static SystemManifest readManifest(QString pathToExportFile) {
-    SystemManifest manifest;
-
-    try {
-      auto content = FileHelpers::readFile(pathToExportFile);
-      manifest = parseJSONItem<SystemManifest>(content, &SystemManifest::deserialize);
-      manifest.pathToManifest = FileHelpers::getDirname(pathToExportFile);
-    }
-    catch (const FileError& e) {
-      std::cout << "Got an exception: " << e.what() << std::endl;
-    }
-
-    return manifest;
-  }
-
-  static QString contentSensitiveFilename(QString contentType) {
-    if (contentType == Codeblock::contentType()) {
-      return Codeblock::mkName();
-    }
-    else if(contentType == Screenshot::contentType()) {
-      return Screenshot::mkName();
-    }
-    else {
-      return FileHelpers::randomFilename("ashirt_unknown_type.bin");
-    }
-  }
-
-  static QString contentSensitiveExtension(QString contentType) {
-    if (contentType == Codeblock::contentType()) {
-      return Codeblock::extension();
-    }
-    else if(contentType == Screenshot::contentType()) {
-      return Screenshot::extension();
-    }
-    else {
-      return FileHelpers::randomFilename("bin");
-    }
-  }
-
-  static QJsonObject serialize(SystemManifest src) {
-    QJsonObject o;
-    o.insert("operatingSystem", src.os);
-    o.insert("databasePath", src.dbPath);
-    o.insert("configPath", src.configPath);
-    o.insert("serversPath", src.serversPath);
-    o.insert("evidenceManifestPath", src.evidenceManifestPath);
-    return o;
-  }
-
-  static SystemManifest deserialize(QJsonObject o) {
-    SystemManifest manifest;
-    manifest.os = o.value("operatingSystem").toString();
-    manifest.dbPath = o.value("databasePath").toString();
-    manifest.configPath = o.value("configPath").toString();
-    manifest.serversPath = o.value("serversPath").toString();
-    manifest.evidenceManifestPath = o.value("evidenceManifestPath").toString();
-    return manifest;
-  }
+  /**
+   * @brief readManifest parses the the system.json (as provided by the caller) into a complete SystemManifest
+   * @param pathToExportFile the location of the system.json file
+   * @return the completed SystemManifest
+   */
+  static SystemManifest readManifest(QString pathToExportFile);
 
  public:
-  void applyManifest(SystemManifestImportOptions options, DatabaseConnection* systemDb) {
-    bool shouldMigrateConfig = options.importConfig && !configPath.isEmpty();
-    bool shouldMigrateDb = options.importDb == SystemManifestImportOptions::Merge && !dbPath.isEmpty();
+  static QJsonObject serialize(const SystemManifest& src);
 
-    try {
-      if (shouldMigrateConfig) {
-        migrateConfig();
-      }
+  static SystemManifest deserialize(QJsonObject o);
 
-      if (shouldMigrateDb) {
-        migrateDb(systemDb);
-      }
-    }
-    catch (const FileError& e) {
-      std::cout << "Got an exception: " << e.what() << std::endl;
-    }
-  }
+ private:
+  /// contentSensitiveFilename returns a (random) filename for the given content type. This, in turn,
+  /// relies on the underlying type to provide a sensible value. If no match is found, then
+  /// "ashirt_unknown_type_XXXXXX.bin" (X's will be replaced with random characters) is returned instead.
+  /// @see FileHelpers::randomFilename
+  static QString contentSensitiveFilename(QString contentType);
+
+  /// contentSensitiveExtension returns a file extension for the given content type. This, in turn,
+  /// relies on the underlying type to provide a sensible value. If no match is found, then ".bin"
+  /// is returned instead
+  static QString contentSensitiveExtension(QString contentType);
+
+
+
+ public:
+  /**
+   * @brief applyManifest
+   * @param options
+   * @param systemDb
+   * @throws FileError
+   * @throws QSqlError
+   */
+  void applyManifest(SystemManifestImportOptions options, DatabaseConnection* systemDb);
+
+  /**
+   * @brief exportManifest starts the long process of copying config and evidence into the specified directory.
+   * @param db the connection to the primary database
+   * @param outputDirPath the path to the expected export directory. Files will be placed under this directory
+   * (not wrapped in another directory)
+   * @param options exporting options (e.g. do you want to copy both evidence *and* config
+   * @throws FileError if there is a problem with the given directory, or with a generated filename
+   * @throws QSqlError if there is an issue accessing the system database, or the copied database
+   */
+  void exportManifest(DatabaseConnection* db, QString outputDirPath, const SystemManifestExportOptions& options);
 
 
  private:
-  void migrateConfig() {
-    auto data = FileHelpers::readFile(pathToFile(configPath));
-    parseJSONItem<QString>(data, [](QJsonObject src) {
-      for(QString key : src.keys()) {
-        src.remove("evidenceRepo"); // removing evidenceRepo, as we never want to replace what the user has set there.
+  /**
+   * @brief migrateConfig
+   * @throws FileError
+   */
+  void migrateConfig();
+  /**
+   * @brief migrateDb
+   * @param systemDb
+   * @throws QSqlError
+   */
+  void migrateDb(DatabaseConnection* systemDb);
+  QString pathToFile(QString filename);
 
-        // only opting to migrate connection settings, given that translating other options may
-        // cause problems (especially if migrating between oses)
-        if (key != "accessKey" && key != "secretKey" && key != "apiURL") {
-          src.remove(key);
-        }
-      }
-      AppConfig::getInstance().applyConfig(src);
-      return "";
-    });
-    AppConfig::getInstance().writeConfig(); // save updated config
-  }
-
-  void migrateDb(DatabaseConnection* systemDb) {
-    auto evidenceManifest = EvidenceManifest::deserialize(pathToFile(evidenceManifestPath));
-    DatabaseConnection::withConnection(pathToFile(dbPath), "importDb",
-                                       [this, evidenceManifest, systemDb](DatabaseConnection importDb) {
-      // migrate evidence (make new file, copy content, create db entry)
-      for (auto item : evidenceManifest.entries) {
-        auto importRecord = importDb.getEvidenceDetails(item.evidenceID);
-        if (importRecord.id == 0) {
-          continue; // in the odd situation that evidence doesn't match up, just skip it
-        }
-        QString newEvidencePath = AppConfig::getInstance().evidenceRepo + "/" +
-                                  importRecord.operationSlug + "/" +
-                                  contentSensitiveFilename(importRecord.contentType);
-        QString newEviPathLastFour = newEvidencePath.right(4);
-
-        auto fullFileExportPath = pathToManifest + "/" + item.exportPath;
-        auto success = FileHelpers::copyFile(fullFileExportPath, newEvidencePath, true);
-        importRecord.path = newEvidencePath;
-        qint64 evidenceID = systemDb->createFullEvidence(importRecord);
-        systemDb->setEvidenceTags(importRecord.tags, evidenceID);
-      }
-    });
-  }
-
-  QString pathToFile(QString filename) { return pathToManifest + "/" + filename; }
+  /**
+   * @brief copyEvidence
+   * @param baseExportPath
+   * @param allEvidence
+   * @throws QSqlError
+   * @return
+   */
+  sync::EvidenceManifest copyEvidence(QString baseExportPath, std::vector<model::Evidence> allEvidence);
 
 
  public:

--- a/src/porting/system_porting_options.h
+++ b/src/porting/system_porting_options.h
@@ -1,0 +1,36 @@
+#ifndef SYSTEM_OPTIONS_H
+#define SYSTEM_OPTIONS_H
+
+namespace sync {
+
+class SystemManifestExportOptions {
+
+ public:
+  bool includesAnything() const {
+    return exportConfig || exportDb;
+  }
+
+ public:
+  bool exportConfig = true;
+  bool exportDb = true;
+};
+
+class SystemManifestImportOptions {
+ public:
+  enum ImportAction {
+    None = 0,
+    Merge = 1,
+    };
+
+  bool includesAnything() const {
+    return importConfig || (importDb != None);
+  }
+
+ public:
+  bool importConfig = true;
+  ImportAction importDb = Merge;
+};
+
+}
+
+#endif // SYSTEM_OPTIONS_H

--- a/src/porting/system_porting_options.h
+++ b/src/porting/system_porting_options.h
@@ -1,7 +1,7 @@
 #ifndef SYSTEM_OPTIONS_H
 #define SYSTEM_OPTIONS_H
 
-namespace sync {
+namespace porting {
 
 class SystemManifestExportOptions {
 

--- a/src/porting/system_porting_options.h
+++ b/src/porting/system_porting_options.h
@@ -3,31 +3,51 @@
 
 namespace porting {
 
+/**
+ * @brief The SystemManifestExportOptions class provides a set of options for creating a SystemManifest
+ * specifically for exporting
+ */
 class SystemManifestExportOptions {
 
  public:
+  /// includesAnything is a simple function that checks if any export option is "true" (i.e. something that
+  /// can be exported).
   bool includesAnything() const {
     return exportConfig || exportDb;
   }
 
  public:
+  /// exportConfig is a flag that denotes if the configuration file shall be exported. True = Yes, export. False = No, do not export
   bool exportConfig = true;
+  /// exportDb is a flag that denotes if the database (and evidence files) shall be exported. True = Yes, export. False = No, do not export
   bool exportDb = true;
 };
 
+/**
+ * @brief The SystemManifestImportOptions class provides a set of options for creating a SystemManifest
+ * specifically for importing
+ */
 class SystemManifestImportOptions {
  public:
+  /// ImportAction represents the kind of import that can take place for evidence. The only options
+  /// currently are Merge (yes, import) or None (no, don't import)
   enum ImportAction {
+    /// None indicates to the importer that evidence SHOULD NOT be imported
     None = 0,
+    /// Merge indicates to the importer that evidence SHOULD be imported
     Merge = 1,
     };
 
+  /// includesAnything is a simple function that checks if any import option is set to add data
+  /// (i.e. that there is work to be done)
   bool includesAnything() const {
     return importConfig || (importDb != None);
   }
 
  public:
+  /// importConfig is a flag that denotes if the configuration file shall be imported. True = Yes, import. False = No, do not import
   bool importConfig = true;
+  /// importDb is an ImportAction that determines HOW importing should proceed.
   ImportAction importDb = Merge;
 };
 

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -183,7 +183,6 @@ void TrayManager::wireUi() {
   connect(addCodeblockAction, actTriggered, this, &TrayManager::captureCodeblockActionTriggered);
   connect(newOperationAction, actTriggered, [this, toTop](){toTop(createOperationWindow);});
 
-  //portCompleted(QString path)
   connect(exportWindow, &PortingDialog::portCompleted, [this](QString path) {
     openServicesPath = path;
     setTrayMessage(OPEN_PATH, "Export Complete", "Export saved to: " + path);

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -36,6 +36,7 @@
 #include "hotkeymanager.h"
 #include "models/codeblock.h"
 #include "tools/UGlobalHotkey/uglobalhotkeys.h"
+#include "porting/system_manifest.h"
 
 // Tray icons are handled differently between different OS and desktop
 // environments. MacOS uses a monochrome mask to render a light or dark icon
@@ -70,6 +71,9 @@ TrayManager::TrayManager(DatabaseConnection* db) {
 TrayManager::~TrayManager() {
   setVisible(false);
 
+  delete exportAction;
+  delete importAction;
+
   delete quitAction;
   delete showSettingsAction;
   delete currentOperationMenuAction;
@@ -91,6 +95,8 @@ TrayManager::~TrayManager() {
   delete hotkeyManager;
   delete settingsWindow;
   delete evidenceManagerWindow;
+  delete importWindow;
+  delete exportWindow;
   delete creditsWindow;
 }
 
@@ -99,6 +105,8 @@ void TrayManager::buildUi() {
   settingsWindow = new Settings(hotkeyManager, this);
   evidenceManagerWindow = new EvidenceManager(db, this);
   creditsWindow = new Credits(this);
+  importWindow = new PortingDialog(PortingDialog::Import, db, this);
+  exportWindow = new PortingDialog(PortingDialog::Export, db, this);
 
   trayIconMenu = new QMenu(this);
   chooseOpSubmenu = new QMenu(tr("Select Operation"));
@@ -119,6 +127,8 @@ void TrayManager::buildUi() {
   addToTray(tr(""), &currentOperationMenuAction);
   trayIconMenu->addMenu(chooseOpSubmenu);
   trayIconMenu->addSeparator();
+  addToTray(tr("Export"), &exportAction);
+  addToTray(tr("Import"), &importAction);
   addToTray(tr("About"), &showCreditsAction);
   addToTray(tr("Quit"), &quitAction);
 
@@ -152,6 +162,8 @@ void TrayManager::wireUi() {
   auto actTriggered = &QAction::triggered;
   // connect actions
   connect(quitAction, actTriggered, qApp, &QCoreApplication::quit);
+  connect(exportAction, actTriggered, [this, toTop](){toTop(exportWindow);});
+  connect(importAction, actTriggered, [this, toTop](){toTop(importWindow);});
   connect(showSettingsAction, actTriggered, [this, toTop](){toTop(settingsWindow);});
   connect(captureScreenAreaAction, actTriggered, this, &TrayManager::captureAreaActionTriggered);
   connect(captureWindowAction, actTriggered, this, &TrayManager::captureWindowActionTriggered);

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -185,7 +185,7 @@ void TrayManager::wireUi() {
 
   connect(exportWindow, &PortingDialog::portCompleted, [this](QString path) {
     openServicesPath = path;
-    setTrayMessage(OPEN_PATH, "Export Complete", "Export saved to: " + path);
+    setTrayMessage(OPEN_PATH, "Export Complete", "Export saved to: " + path + "\nClick to view");
   });
   connect(importWindow, &PortingDialog::portCompleted, [this](QString path) {
     setTrayMessage(NO_ACTION, "Import Complete", "Import retrieved from: " + path);

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -86,6 +86,7 @@ TrayManager::~TrayManager() {
 
   delete chooseOpStatusAction;
   delete chooseOpSubmenu;
+  delete settingsSubmenu;
 
   delete updateCheckTimer;
   delete trayIconMenu;
@@ -109,35 +110,41 @@ void TrayManager::buildUi() {
   exportWindow = new PortingDialog(PortingDialog::Export, db, this);
 
   trayIconMenu = new QMenu(this);
-  chooseOpSubmenu = new QMenu(tr("Select Operation"));
 
-  // small helper to create an action and assign it to the tray
-  auto addToTray = [this](QString text, QAction** act){
-    *act = new QAction(text, this);
-    trayIconMenu->addAction(*act);
+  auto addMenuToMenu = [this](QString text, QMenu** submenu, QMenu** parent) {
+    *submenu = new QMenu(text, this);
+    (*parent)->addMenu(*submenu);
   };
 
-  // Tray Ordering
-  addToTray(tr("Add Codeblock from Clipboard"), &addCodeblockAction);
-  addToTray(tr("Capture Screen Area"), &captureScreenAreaAction);
-  addToTray(tr("Capture Window"), &captureWindowAction);
-  addToTray(tr("View Accumulated Evidence"), &showEvidenceManagerAction);
-  addToTray(tr("Settings"), &showSettingsAction);
-  trayIconMenu->addSeparator();
-  addToTray(tr(""), &currentOperationMenuAction);
-  trayIconMenu->addMenu(chooseOpSubmenu);
-  trayIconMenu->addSeparator();
-  addToTray(tr("Export"), &exportAction);
-  addToTray(tr("Import"), &importAction);
-  addToTray(tr("About"), &showCreditsAction);
-  addToTray(tr("Quit"), &quitAction);
+  // small helper to create an action and assign it to a menu
+  auto addToMenu = [this](QString text, QAction** act, QMenu** menu) {
+    *act = new QAction(text, this);
+    (*menu)->addAction(*act);
+  };
 
-  // finish action config
+  // Tray menu
+  addToMenu(tr("Add Codeblock from Clipboard"), &addCodeblockAction, &trayIconMenu);
+  addToMenu(tr("Capture Screen Area"), &captureScreenAreaAction, &trayIconMenu);
+  addToMenu(tr("Capture Window"), &captureWindowAction, &trayIconMenu);
+  addToMenu(tr("View Accumulated Evidence"), &showEvidenceManagerAction, &trayIconMenu);
+  trayIconMenu->addSeparator();
+  addToMenu(tr(""), &currentOperationMenuAction, &trayIconMenu);
+  addMenuToMenu(tr("Select Operation"), &chooseOpSubmenu, &trayIconMenu);
+  trayIconMenu->addSeparator();
+  addMenuToMenu(tr("Edit"), &settingsSubmenu, &trayIconMenu);
+  addToMenu(tr("About"), &showCreditsAction, &trayIconMenu);
+  addToMenu(tr("Quit"), &quitAction, &trayIconMenu);
+
+  // Operations Submenu
   currentOperationMenuAction->setEnabled(false);
-  chooseOpStatusAction = new QAction("Loading operations...", chooseOpSubmenu);
+  addToMenu(tr("Loading operations..."), &chooseOpStatusAction, &chooseOpSubmenu);
   chooseOpStatusAction->setEnabled(false);
-  chooseOpSubmenu->addAction(chooseOpStatusAction);
   chooseOpSubmenu->addSeparator();
+
+  // settings submenu
+  addToMenu(tr("Settings"), &showSettingsAction, &settingsSubmenu);
+  addToMenu(tr("Export Data"), &exportAction, &settingsSubmenu);
+  addToMenu(tr("Import Data"), &importAction, &settingsSubmenu);
 
   setActiveOperationLabel();
 

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -112,13 +112,13 @@ void TrayManager::buildUi() {
 
   trayIconMenu = new QMenu(this);
 
-  auto addMenuToMenu = [this](QString text, QMenu** submenu, QMenu** parent) {
+  auto addMenuToMenu = [this](const QString& text, QMenu** submenu, QMenu** parent) {
     *submenu = new QMenu(text, this);
     (*parent)->addMenu(*submenu);
   };
 
   // small helper to create an action and assign it to a menu
-  auto addToMenu = [this](QString text, QAction** act, QMenu** menu) {
+  auto addToMenu = [this](const QString& text, QAction** act, QMenu** menu) {
     *act = new QAction(text, this);
     (*menu)->addAction(*act);
   };
@@ -183,11 +183,11 @@ void TrayManager::wireUi() {
   connect(addCodeblockAction, actTriggered, this, &TrayManager::captureCodeblockActionTriggered);
   connect(newOperationAction, actTriggered, [this, toTop](){toTop(createOperationWindow);});
 
-  connect(exportWindow, &PortingDialog::portCompleted, [this](QString path) {
+  connect(exportWindow, &PortingDialog::portCompleted, [this](const QString& path) {
     openServicesPath = path;
     setTrayMessage(OPEN_PATH, "Export Complete", "Export saved to: " + path + "\nClick to view");
   });
-  connect(importWindow, &PortingDialog::portCompleted, [this](QString path) {
+  connect(importWindow, &PortingDialog::portCompleted, [this](const QString& path) {
     setTrayMessage(NO_ACTION, "Import Complete", "Import retrieved from: " + path);
   });
 
@@ -243,17 +243,17 @@ void TrayManager::closeEvent(QCloseEvent* event) {
 
 void TrayManager::spawnGetInfoWindow(qint64 evidenceID) {
   auto getInfoWindow = new GetInfo(db, evidenceID, this);
-  connect(getInfoWindow, &GetInfo::evidenceSubmitted, [](model::Evidence evi){
+  connect(getInfoWindow, &GetInfo::evidenceSubmitted, [](const model::Evidence& evi){
     AppSettings::getInstance().setLastUsedTags(evi.tags);
   });
   getInfoWindow->show();
 }
 
-qint64 TrayManager::createNewEvidence(QString filepath, QString evidenceType) {
+qint64 TrayManager::createNewEvidence(const QString& filepath, const QString& evidenceType) {
   AppSettings& inst = AppSettings::getInstance();
   auto evidenceID = db->createEvidence(filepath, inst.operationSlug(), evidenceType);
   auto tags = inst.getLastUsedTags();
-  if (tags.size() > 0) {
+  if (!tags.empty()) {
     db->setEvidenceTags(tags, evidenceID);
   }
   return evidenceID;
@@ -368,7 +368,7 @@ void TrayManager::checkForUpdate() {
   NetMan::getInstance().checkForNewRelease(Constants::releaseOwner(), Constants::releaseRepo());
 }
 
-void TrayManager::onReleaseCheck(bool success, std::vector<dto::GithubRelease> releases) {
+void TrayManager::onReleaseCheck(bool success, const std::vector<dto::GithubRelease>& releases) {
   if (!success) {
     return;  // doesn't matter if this fails -- another request will be made later.
   }
@@ -380,7 +380,7 @@ void TrayManager::onReleaseCheck(bool success, std::vector<dto::GithubRelease> r
   }
 }
 
-void TrayManager::setTrayMessage(MessageType type, QString title, QString message,
+void TrayManager::setTrayMessage(MessageType type, const QString& title, const QString& message,
                                  QSystemTrayIcon::MessageIcon icon, int millisecondsTimeoutHint) {
   trayIcon->showMessage(title, message, icon, millisecondsTimeoutHint);
   this->currentTrayMessage = type;

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -184,10 +184,11 @@ void TrayManager::wireUi() {
   connect(newOperationAction, actTriggered, [this, toTop](){toTop(createOperationWindow);});
 
   //portCompleted(QString path)
-  connect(exportWindow, &PortingDialog::portCompleted, [this](QString path){
-    setTrayMessage(NO_ACTION, "Export Complete", "Export saved to: " + path);
+  connect(exportWindow, &PortingDialog::portCompleted, [this](QString path) {
+    openServicesPath = path;
+    setTrayMessage(OPEN_PATH, "Export Complete", "Export saved to: " + path);
   });
-  connect(importWindow, &PortingDialog::portCompleted, [this](QString path){
+  connect(importWindow, &PortingDialog::portCompleted, [this](QString path) {
     setTrayMessage(NO_ACTION, "Import Complete", "Import retrieved from: " + path);
   });
 
@@ -391,6 +392,8 @@ void TrayManager::onTrayMessageClicked() {
     case UPGRADE:
       QDesktopServices::openUrl(Constants::releasePageUrl());
       break;
+    case OPEN_PATH:
+      QDesktopServices::openUrl(openServicesPath);
     case NO_ACTION:
     default:
       break;

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -86,7 +86,7 @@ TrayManager::~TrayManager() {
 
   delete chooseOpStatusAction;
   delete chooseOpSubmenu;
-  delete settingsSubmenu;
+  delete importExportSubmenu;
 
   delete updateCheckTimer;
   delete trayIconMenu;
@@ -132,7 +132,8 @@ void TrayManager::buildUi() {
   addToMenu(tr(""), &currentOperationMenuAction, &trayIconMenu);
   addMenuToMenu(tr("Select Operation"), &chooseOpSubmenu, &trayIconMenu);
   trayIconMenu->addSeparator();
-  addMenuToMenu(tr("Edit"), &settingsSubmenu, &trayIconMenu);
+  addMenuToMenu(tr("Import/Export"), &importExportSubmenu, &trayIconMenu);
+  addToMenu(tr("Settings"), &showSettingsAction, &trayIconMenu);
   addToMenu(tr("About"), &showCreditsAction, &trayIconMenu);
   addToMenu(tr("Quit"), &quitAction, &trayIconMenu);
 
@@ -146,9 +147,9 @@ void TrayManager::buildUi() {
   chooseOpSubmenu->addSeparator();
 
   // settings submenu
-  addToMenu(tr("Settings"), &showSettingsAction, &settingsSubmenu);
-  addToMenu(tr("Export Data"), &exportAction, &settingsSubmenu);
-  addToMenu(tr("Import Data"), &importAction, &settingsSubmenu);
+
+  addToMenu(tr("Export Data"), &exportAction, &importExportSubmenu);
+  addToMenu(tr("Import Data"), &importAction, &importExportSubmenu);
 
   setActiveOperationLabel();
 

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -36,6 +36,11 @@ class QSpinBox;
 class QTextEdit;
 QT_END_NAMESPACE
 
+enum MessageType {
+  NO_ACTION,
+  UPGRADE,
+};
+
 class TrayManager : public QDialog {
   Q_OBJECT
 
@@ -51,10 +56,13 @@ class TrayManager : public QDialog {
   void showNoOperationSetTrayMessage();
   void checkForUpdate();
   void cleanChooseOpSubmenu();
+  void setTrayMessage(MessageType type, QString title, QString message,
+                      QSystemTrayIcon::MessageIcon icon=QSystemTrayIcon::Information, int millisecondsTimeoutHint = 10000);
 
  private slots:
   void onOperationListUpdated(bool success, const std::vector<dto::Operation> &operations);
   void onReleaseCheck(bool success, std::vector<dto::GithubRelease> releases);
+  void onTrayMessageClicked();
 
  public slots:
   void onScreenshotCaptured(const QString &filepath);
@@ -72,6 +80,7 @@ class TrayManager : public QDialog {
   HotkeyManager *hotkeyManager = nullptr;
   Screenshot *screenshotTool = nullptr;
   QTimer *updateCheckTimer = nullptr;
+  MessageType currentTrayMessage = NO_ACTION;
 
   // Subwindows
   Settings *settingsWindow = nullptr;

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -59,19 +59,19 @@ class TrayManager : public QDialog {
  private:
   void buildUi();
   void wireUi();
-  qint64 createNewEvidence(QString filepath, QString evidenceType);
+  qint64 createNewEvidence(const QString& filepath, const QString& evidenceType);
   void spawnGetInfoWindow(qint64 evidenceID);
   void showNoOperationSetTrayMessage();
   void checkForUpdate();
   void cleanChooseOpSubmenu();
   /// setTrayMessage mostly mirrors QSystemTrayIcon::showMessage, but adds the ability to set a message type,
   /// providing a mechanism to smartly route the click to an action.
-  void setTrayMessage(MessageType type, QString title, QString message,
+  void setTrayMessage(MessageType type, const QString& title, const QString& message,
                       QSystemTrayIcon::MessageIcon icon=QSystemTrayIcon::Information, int millisecondsTimeoutHint = 10000);
 
  private slots:
   void onOperationListUpdated(bool success, const std::vector<dto::Operation> &operations);
-  void onReleaseCheck(bool success, std::vector<dto::GithubRelease> releases);
+  void onReleaseCheck(bool success, const std::vector<dto::GithubRelease>& releases);
   void onTrayMessageClicked();
 
  public slots:

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -115,7 +115,7 @@ class TrayManager : public QDialog {
   QAction *showCreditsAction = nullptr;
   QAction *addCodeblockAction = nullptr;
 
-  QMenu *settingsSubmenu = nullptr;
+  QMenu *importExportSubmenu = nullptr;
   QAction *exportAction = nullptr;
   QAction *importAction = nullptr;
   QAction *showSettingsAction = nullptr;

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -12,6 +12,7 @@
 #include "dtos/github_release.h"
 #include "forms/credits/credits.h"
 #include "forms/evidence/evidencemanager.h"
+#include "forms/porting/porting_dialog.h"
 #include "forms/settings/settings.h"
 #include "helpers/screenshot.h"
 #include "hotkeymanager.h"
@@ -75,12 +76,16 @@ class TrayManager : public QDialog {
   Settings *settingsWindow = nullptr;
   EvidenceManager *evidenceManagerWindow = nullptr;
   Credits *creditsWindow = nullptr;
+  PortingDialog *importWindow = nullptr;
+  PortingDialog *exportWindow = nullptr;
 
   // UI Elements
   QSystemTrayIcon *trayIcon = nullptr;
   QMenu *trayIconMenu = nullptr;
 
   QAction *quitAction = nullptr;
+  QAction *exportAction = nullptr;
+  QAction *importAction = nullptr;
   QAction *showSettingsAction = nullptr;
   QAction *currentOperationMenuAction = nullptr;
   QAction *captureScreenAreaAction = nullptr;

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -39,6 +39,7 @@ QT_END_NAMESPACE
 enum MessageType {
   NO_ACTION,
   UPGRADE,
+  OPEN_PATH
 };
 
 class TrayManager : public QDialog {
@@ -81,6 +82,8 @@ class TrayManager : public QDialog {
   Screenshot *screenshotTool = nullptr;
   QTimer *updateCheckTimer = nullptr;
   MessageType currentTrayMessage = NO_ACTION;
+
+  QString openServicesPath = "";
 
   // Subwindows
   Settings *settingsWindow = nullptr;

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -36,9 +36,16 @@ class QSpinBox;
 class QTextEdit;
 QT_END_NAMESPACE
 
+/**
+ * @brief The MessageType enum specifies how to respond to a click on a tray message
+ * @see openServicesPath
+ */
 enum MessageType {
+  /// NO_ACTION indicates that nothing should happen on a tray message click
   NO_ACTION,
+  /// UPGRADE indicates that the user should be taken to the releases page
   UPGRADE,
+  /// OPEN_PATH indicates that the user should be taken to a file browser
   OPEN_PATH
 };
 
@@ -57,6 +64,8 @@ class TrayManager : public QDialog {
   void showNoOperationSetTrayMessage();
   void checkForUpdate();
   void cleanChooseOpSubmenu();
+  /// setTrayMessage mostly mirrors QSystemTrayIcon::showMessage, but adds the ability to set a message type,
+  /// providing a mechanism to smartly route the click to an action.
   void setTrayMessage(MessageType type, QString title, QString message,
                       QSystemTrayIcon::MessageIcon icon=QSystemTrayIcon::Information, int millisecondsTimeoutHint = 10000);
 
@@ -83,6 +92,7 @@ class TrayManager : public QDialog {
   QTimer *updateCheckTimer = nullptr;
   MessageType currentTrayMessage = NO_ACTION;
 
+  /// openServicesPath is a variable to store where, on click, to open a path the next time a tray message is displayed
   QString openServicesPath = "";
 
   // Subwindows

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -84,15 +84,17 @@ class TrayManager : public QDialog {
   QMenu *trayIconMenu = nullptr;
 
   QAction *quitAction = nullptr;
-  QAction *exportAction = nullptr;
-  QAction *importAction = nullptr;
-  QAction *showSettingsAction = nullptr;
   QAction *currentOperationMenuAction = nullptr;
   QAction *captureScreenAreaAction = nullptr;
   QAction *captureWindowAction = nullptr;
   QAction *showEvidenceManagerAction = nullptr;
   QAction *showCreditsAction = nullptr;
   QAction *addCodeblockAction = nullptr;
+
+  QMenu *settingsSubmenu = nullptr;
+  QAction *exportAction = nullptr;
+  QAction *importAction = nullptr;
+  QAction *showSettingsAction = nullptr;
 
   QMenu *chooseOpSubmenu = nullptr;
   QAction *chooseOpStatusAction = nullptr;


### PR DESCRIPTION
This PR adds the ability for users to export configuration data (namely: server configuration) and evidence, and provides a mechanism for re-import of that data. 

Changes:
This is a fairly extensive change. The database connection class needed to be rewritten to support concurrent access, as well as multiple database. Additional UI has been created to allow the user to import and export, as well as serialization of the evidence data, and updating config to support importing/exporting to a different location. Some supporting methods have also been updated to communicate more useful return data.

Notes:
* ~~Import and export are expected  to be relatively uncommon UI elements, but their placement in the tray does not reflect this. We should come up with a better location for this -- perhaps in a submenu, combined  with settings?~~ Moved Import/Export/Settings under "Edit" submenu in the tray menu
* As a quirk, imports and exports can be done at the same time. One does not affect the other, but if, say, an import was half way through when the export started, the export would feature about half of the newly-imported data.
* Imports can be re-run, but re-running will duplicate the data.
* Imports (And exports) run to completion, baring some thrown exception (i.e. they cannot be cancelled). You can close the window, but the execution continues. However, only one import/export can be done at a time.
* The code has been set up to allow exporting arbitrary evidence, but currently all evidence is exported.

Ultimately, there are a few things we might want to think about modifying before this gets merged in.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.