### PR TITLE
Update evidence content when the filtering changes

### DIFF
--- a/src/components/evidence_editor/evidenceeditor.cpp
+++ b/src/components/evidence_editor/evidenceeditor.cpp
@@ -160,6 +160,8 @@ void EvidenceEditor::clearEditor() {
   this->descriptionTextBox->setText("");
   if (loadedPreview != nullptr) {
     loadedPreview->clearPreview();
+    delete loadedPreview;
+    loadedPreview = nullptr;
   }
 }
 

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -336,6 +336,11 @@ void EvidenceManager::applyFilterForm(const EvidenceFilters& filter) {
 }
 
 void EvidenceManager::loadEvidence() {
+  qint64 reselectId = -1;
+  if (evidenceTable->selectedItems().size() > 0) {
+    reselectId = selectedRowEvidenceID();
+  }
+
   evidenceTable->clearContents();
 
   try {
@@ -365,6 +370,18 @@ void EvidenceManager::loadEvidence() {
       setRowText(row, evi);
     }
     evidenceTable->setSortingEnabled(true);
+    if (evidenceTable->rowCount() > 0) {
+      // try to reselect the last viewed evidence, if it's still in the list
+      int selectRow = 0;
+      for (int rowIndex = 0; rowIndex < evidenceTable->rowCount(); rowIndex++) {
+        auto evidenceID = evidenceTable->item(rowIndex, 0)->data(Qt::UserRole).toLongLong();
+        if(evidenceID == reselectId) {
+          selectRow = rowIndex;
+          break;
+        }
+      }
+      evidenceTable->setCurrentCell(selectRow, 0);
+    }
   }
   catch (QSqlError& e) {
     std::cout << "Could not retrieve evidence for operation. Error: " << e.text().toStdString()

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -177,8 +177,6 @@ void EvidenceManager::wireUi() {
   connect(resetFilterButton, btnClicked, this, &EvidenceManager::resetFilterButtonClicked);
   connect(editFiltersButton, btnClicked, this, &EvidenceManager::openFiltersMenu);
 
-  connect(filterTextBox, &QLineEdit::returnPressed, this, &EvidenceManager::loadEvidence);
-
   connect(submitEvidenceAction, actionTriggered, this, &EvidenceManager::submitEvidenceTriggered);
   connect(deleteEvidenceAction, actionTriggered, this, &EvidenceManager::deleteEvidenceTriggered);
   connect(closeWindowAction, actionTriggered, this, &EvidenceManager::close);


### PR DESCRIPTION
This PR updates the evidence viewed in the evidence manager when the filtering changes. if the item is still in the list post-filtering, then it is reselected. if it is not, then the first item is selected. If no items are available, then the preview image is cleared.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.