### PR TITLE
Add Qt6 support (does not switch to Qt6)

### DIFF
--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -4,6 +4,7 @@
 #ifndef APPSETTINGS_H
 #define APPSETTINGS_H
 
+#include <QSequentialIterable>
 #include <QSettings>
 #include <QString>
 
@@ -56,11 +57,28 @@ class AppSettings : public QObject {
   QString operationName() { return settings.value(opNameSetting).toString(); }
 
   void setLastUsedTags(std::vector<model::Tag> lastTags) {
-    settings.setValue(lastUsedTagsSetting, QVariant::fromValue(lastTags));
+    QVariantList writeTags;
+    
+    for (auto tag : lastTags) {
+      writeTags << QVariant::fromValue(tag);
+    }
+
+    settings.setValue(lastUsedTagsSetting, QVariant::fromValue(writeTags));
   }
+
   std::vector<model::Tag> getLastUsedTags() {
+    std::vector<model::Tag> rtn;
+
     auto val = settings.value(lastUsedTagsSetting);
-    return qvariant_cast<std::vector<model::Tag>>(val);
+
+    if (val.canConvert<QVariantList>()) {
+      QSequentialIterable iter = val.value<QSequentialIterable>();
+      for (const QVariant& item : iter) {
+        rtn.push_back(qvariant_cast<model::Tag>(item));
+      }
+    }
+
+    return rtn;
   }
 };
 #endif  // APPSETTINGS_H

--- a/src/components/aspectratio_pixmap_label/imageview.cpp
+++ b/src/components/aspectratio_pixmap_label/imageview.cpp
@@ -15,7 +15,7 @@ ImageView::~ImageView() {
 
 void ImageView::buildUi() {
   gridLayout = new QGridLayout(this);
-  gridLayout->setMargin(0);
+  gridLayout->setContentsMargins(0, 0, 0, 0);
 
   previewImage = new AspectRatioPixmapLabel(this);
   previewImage->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));

--- a/src/components/code_editor/codeblockview.cpp
+++ b/src/components/code_editor/codeblockview.cpp
@@ -19,7 +19,7 @@ CodeBlockView::~CodeBlockView() {
 
 void CodeBlockView::buildUi() {
   gridLayout = new QGridLayout(this);
-  gridLayout->setMargin(0);
+  gridLayout->setContentsMargins(0, 0, 0, 0);
 
   _languageLabel = new QLabel("Language", this);
   _sourceLabel = new QLabel("Source", this);

--- a/src/components/error_view/errorview.cpp
+++ b/src/components/error_view/errorview.cpp
@@ -13,7 +13,7 @@ ErrorView::~ErrorView() {
 
 void ErrorView::buildUi() {
   gridLayout = new QGridLayout(this);
-  gridLayout->setMargin(0);
+  gridLayout->setContentsMargins(0, 0, 0, 0);
 
   errorLabel = new QLabel(errorText, this);
 

--- a/src/components/evidence_editor/evidenceeditor.cpp
+++ b/src/components/evidence_editor/evidenceeditor.cpp
@@ -41,7 +41,7 @@ EvidenceEditor::~EvidenceEditor() {
 
 void EvidenceEditor::buildUi() {
   gridLayout = new QGridLayout(this);
-  gridLayout->setMargin(0);
+  gridLayout->setContentsMargins(0, 0, 0, 0);
 
   splitter = new QSplitter(this);
   splitter->setOrientation(Qt::Vertical);
@@ -56,7 +56,7 @@ void EvidenceEditor::buildUi() {
   descriptionArea->setLayout(descriptionAreaLayout);
   descriptionAreaLayout->addWidget(_descriptionLabel);
   descriptionAreaLayout->addWidget(descriptionTextBox);
-  descriptionAreaLayout->setMargin(0);
+  descriptionAreaLayout->setContentsMargins(0, 0, 0, 0);
 
   // Layout
   /*        0

--- a/src/components/evidence_editor/evidenceeditor.cpp
+++ b/src/components/evidence_editor/evidenceeditor.cpp
@@ -3,6 +3,7 @@
 
 #include "evidenceeditor.h"
 
+#include <QFile>
 #include <vector>
 
 #include "components/aspectratio_pixmap_label/imageview.h"

--- a/src/components/flow_layout/flowlayout.cpp
+++ b/src/components/flow_layout/flowlayout.cpp
@@ -100,7 +100,7 @@ QLayoutItem *FlowLayout::takeAt(int index) {
   return nullptr;
 }
 
-Qt::Orientations FlowLayout::expandingDirections() const { return 0; }
+Qt::Orientations FlowLayout::expandingDirections() const { return {}; }
 
 bool FlowLayout::hasHeightForWidth() const { return true; }
 

--- a/src/components/tagging/tageditor.cpp
+++ b/src/components/tagging/tageditor.cpp
@@ -33,7 +33,7 @@ TagEditor::~TagEditor() {
 
 void TagEditor::buildUi() {
   gridLayout = new QGridLayout(this);
-  gridLayout->setMargin(0);
+  gridLayout->setContentsMargins(0, 0, 0, 0);
 
   couldNotCreateTagMsg = new QErrorMessage(this);
 

--- a/src/components/tagging/tagginglineediteventfilter.h
+++ b/src/components/tagging/tagginglineediteventfilter.h
@@ -41,7 +41,7 @@ class TaggingLineEditEventFilter : public QObject {
     if (event->type() == QEvent::KeyPress) {
       QKeyEvent *ke = static_cast<QKeyEvent *>(event);
 
-      if (matchesKey(ke, QKeySequence(Qt::CTRL + Qt::Key_Space))) {
+      if (matchesKey(ke, QKeySequence(Qt::CTRL | Qt::Key_Space))) {
         emit completePressed();
         return true;
       }

--- a/src/components/tagging/tagview.cpp
+++ b/src/components/tagging/tagview.cpp
@@ -16,7 +16,7 @@ TagView::~TagView() {
 
 void TagView::buildUi() {
   mainLayout = new QHBoxLayout(this);
-  mainLayout->setMargin(0);
+  mainLayout->setContentsMargins(0, 0, 0, 0);
 
   tagGroupBox = new QGroupBox("Tags", this);
   layout = new FlowLayout();

--- a/src/forms/evidence_filter/evidencefilter.cpp
+++ b/src/forms/evidence_filter/evidencefilter.cpp
@@ -133,14 +133,14 @@ Tri EvidenceFilters::parseTriFilterValue(const QString& text, bool strict) {
 }
 
 std::vector<std::pair<QString, QString>> EvidenceFilters::tokenizeFilterText(const QString& text) {
-  QStringList list = text.split(":", QString::SplitBehavior::SkipEmptyParts);
+  QStringList list = text.split(":", Qt::SkipEmptyParts);
   // now in: [Key][value key]...[value] format
   QStringList keys;
   QStringList values;
   keys.append(list.first());
 
   for (int i = 1; i < list.size() - 1; i++) {
-    auto valueKeyPair = list.at(i).split(" ", QString::SplitBehavior::SkipEmptyParts);
+    auto valueKeyPair = list.at(i).split(" ", Qt::SkipEmptyParts);
     keys.append(valueKeyPair.last());
     valueKeyPair.removeLast();
     values.append(valueKeyPair.join(" "));

--- a/src/forms/evidence_filter/evidencefilter.h
+++ b/src/forms/evidence_filter/evidencefilter.h
@@ -8,6 +8,7 @@
 #include <QString>
 #include <utility>
 #include <vector>
+#include <QStringList>
 
 enum Tri { Any, Yes, No };
 

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -292,10 +292,8 @@ void Settings::onTestRequestComplete() {
         connStatusLabel->setText("Could not connect: Not Found (check URL)");
         break;
       default:
-        QString msg = "Could not connect: Unexpected Error (code: ";
-        msg.append(statusCode);
-        msg.append(")");
-        connStatusLabel->setText(msg);
+        QString msg = "Could not connect: Unexpected Error (code: %1)";
+        connStatusLabel->setText(msg.arg(statusCode));
     }
   }
   else {

--- a/src/helpers/constants.h
+++ b/src/helpers/constants.h
@@ -18,18 +18,18 @@ class Constants {
 
   static QString configLocation() {
 #ifdef Q_OS_MACOS
-    return QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/config.json";
+    return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/config.json";
 #else
     return QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + "/ashirt/config.json";
 #endif
   }
 
   static QString dbLocation() {
-    return QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/evidence.sqlite";
+    return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/evidence.sqlite";
   }
 
   static QString defaultEvidenceRepo() {
-    return QStandardPaths::writableLocation(QStandardPaths::DataLocation) + "/evidence";
+    return QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation) + "/evidence";
   }
 
   static QString releaseOwner() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@ void handleCLI(std::vector<std::string> args);
 #ifndef QT_NO_SYSTEMTRAYICON
 #include <QApplication>
 #include <QMessageBox>
+#include <QMetaType>
 
 #include "appconfig.h"
 #include "appsettings.h"
@@ -18,38 +19,6 @@ void handleCLI(std::vector<std::string> args);
 #include "exceptions/databaseerr.h"
 #include "exceptions/fileerror.h"
 #include "traymanager.h"
-
-QDataStream& operator<<(QDataStream& out, const model::Tag& v) {
-  out << v.tagName << v.id << v.serverTagId;
-  return out;
-}
-
-QDataStream& operator>>(QDataStream& in, model::Tag& v) {
-  in >> v.tagName;
-  in >> v.id;
-  in >> v.serverTagId;
-  return in;
-}
-
-QDataStream& operator<<(QDataStream& out, const std::vector<model::Tag>& v) {
-  out << int(v.size());
-  for (auto tag : v) {
-    out << tag;
-  }
-  return out;
-}
-
-QDataStream& operator>>(QDataStream& in, std::vector<model::Tag>& v) {
-  int qty;
-  in >> qty;
-  v.reserve(qty);
-  for(int i = 0; i < qty; i++) {
-    model::Tag t;
-    in >> t;
-    v.push_back(t);
-  }
-  return in;
-}
 
 int main(int argc, char* argv[]) {
   Q_INIT_RESOURCE(res_icons);
@@ -91,6 +60,7 @@ int main(int argc, char* argv[]) {
     qRegisterMetaTypeStreamOperators<model::Tag>("Tag");
     qRegisterMetaTypeStreamOperators<std::vector<model::Tag>>("TagVector");
     QApplication app(argc, argv);
+    qRegisterMetaType<model::Tag>();
 
     if (!QSystemTrayIcon::isSystemTrayAvailable()) {
       handleCLI(std::vector<std::string>(argv, argv + argc));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,8 +57,10 @@ int main(int argc, char* argv[]) {
 
   int rtn;
   try {
+#if #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     qRegisterMetaTypeStreamOperators<model::Tag>("Tag");
     qRegisterMetaTypeStreamOperators<std::vector<model::Tag>>("TagVector");
+#endif
     QApplication app(argc, argv);
     qRegisterMetaType<model::Tag>();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[]) {
 
   int rtn;
   try {
-#if #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     qRegisterMetaTypeStreamOperators<model::Tag>("Tag");
     qRegisterMetaTypeStreamOperators<std::vector<model::Tag>>("TagVector");
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,6 @@ int main(int argc, char* argv[]) {
   try {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     qRegisterMetaTypeStreamOperators<model::Tag>("Tag");
-    qRegisterMetaTypeStreamOperators<std::vector<model::Tag>>("TagVector");
 #endif
     QApplication app(argc, argv);
     qRegisterMetaType<model::Tag>();

--- a/src/models/tag.h
+++ b/src/models/tag.h
@@ -14,11 +14,25 @@ class Tag {
   Tag() = default;
   ~Tag() = default;
   Tag(const Tag &) = default;
+  Tag& operator=(const Tag&) = default;
 
   Tag(qint64 id, qint64 tagId, QString name) : Tag(tagId, name) { this->id = id; }
   Tag(qint64 tagId, QString name) {
     this->serverTagId = tagId;
     this->tagName = name;
+  }
+
+ public:
+  friend QDataStream& operator<<(QDataStream& out, const model::Tag& v) {
+    out << v.tagName << v.id << v.serverTagId;
+    return out;
+  }
+
+  friend QDataStream& operator>>(QDataStream& in, model::Tag& v) {
+    in >> v.tagName;
+    in >> v.id;
+    in >> v.serverTagId;
+    return in;
   }
 
  public:

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -7,23 +7,13 @@
 
 #include <QAction>
 #include <QApplication>
-#include <QCheckBox>
 #include <QCloseEvent>
-#include <QComboBox>
 #include <QCoreApplication>
-#include <QDesktopWidget>
-#include <QGroupBox>
-#include <QLabel>
-#include <QLineEdit>
 #include <QMenu>
 #include <QMessageBox>
-#include <QPushButton>
-#include <QSpinBox>
-#include <QTextEdit>
-#include <QVBoxLayout>
-#include <iostream>
 #include <QTimer>
 #include <QDesktopServices>
+#include <iostream>
 
 #include "appconfig.h"
 #include "appsettings.h"


### PR DESCRIPTION
This PR introduces the necessary changes to make this application Qt6 compatible. Note that this does not change the version to Qt6, but instead uses paradigms common to both Qt5 and 6. Generally, this opts to use non-deprecated methods, and accounts for some changes that are specific to Qt6, but don't significantly alter the way Qt5 works.

Breaking changes:
* The serialization format  for lastUsedTags changes in this version. When this PR is applied, the first time a user starts up an application and records new evidence, they will need to select all tags appropriate for that new piece of evidence (rather than starting from a list of existing tags from the last run). All future evidence will then use the new serialization format, and lastUsedTags will function correctly.

Note: There are two additional steps to make this Qt6 compliant:
* Complete   ~UGlobalHotkey requires a small update as well, since it had some non-compliant Qt6 code.~
* This should probably be done in a separate PR when we decide to switch to Qt6 (though there are no errors doing so now) ~Qt6 opts to use C++17 as it's base compiled version. This repo will do the same, but no changes are expected here.~
* This should probably be done in a separate PR.  ~We may switch to CMake over QMake, but this maybe should be done on a proper switchover to Qt6~

For the above reasons, this PR is being marked as a draft until the above items are completed/addressed

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.