### PR TITLE
JK Sign and Notarize

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,10 +42,6 @@ jobs:
 
     - name: Build (mac)
       if: matrix.os == 'macos-latest'
-      env: 
-        MACOS_CERT: ${{ secrets.MACOS_CERT }}
-        MACOS_PASS: ${{ secrets.MACOS_PASS }}
-        MACOS_KEYC: ${{ secrets.MACOS_KEYC }}
       run: |
         brew install qt
         export PATH="/usr/local/opt/qt/bin:$PATH"
@@ -53,12 +49,25 @@ jobs:
         qmake -config release
         make
         macdeployqt ashirt.app -dmg
+        mkdir dist
+        cp -r ashirt.dmg dist/
+        cp LICENSE dist/LICENSE
+        cp README.md dist/README.md
+
+    - name: Sign (mac)
+      if: matrix.os == 'macos-latest'
+      env: 
+        MACOS_CERT: ${{ secrets.MACOS_CERT }}
+        MACOS_PASS: ${{ secrets.MACOS_PASS }}
+        MACOS_KEYC: ${{ secrets.MACOS_KEYC }}
+      run: |
         echo $MACOS_CERT | base64 —-decode > certificate.p12
         security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
         security unlock-keychain -p $MACOS_KEYC build.keychain
         security import certificate.p12 -k build.keychain -P $MACOS_PASS -T /usr/bin/codesign
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYC build.keychain
         /usr/bin/codesign --force -s ashirt ashirt.app -v
+        macdeployqt ashirt.app -dmg
         mkdir dist
         cp -r ashirt.dmg dist/
         cp LICENSE dist/LICENSE

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,10 +68,7 @@ jobs:
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYC build.keychain
         /usr/bin/codesign --force -s ashirt ashirt.app -v
         macdeployqt ashirt.app -dmg
-        mkdir dist
         cp -r ashirt.dmg dist/
-        cp LICENSE dist/LICENSE
-        cp README.md dist/README.md
 
     - name: Archive production artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
         id: create-release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
@@ -119,7 +119,7 @@ jobs:
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ashirt-${{ env.version }}-${{ matrix.platform }}.zip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,9 @@ jobs:
         MACOS_KEYC: ${{ secrets.MACOS_KEYC }}
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |
+        which base64
+        which b64
+        base64 -h
         echo ${{ secrets.GON_CONF }} | base64 --decode > sign.json
         echo $MACOS_CERT | base64 —-decode > certificate.p12
         security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,11 +40,7 @@ jobs:
         submodules: true
 
     - name: Build PR (mac)
-      if: |
-        matrix.os == 'macos-latest' && 
-        !contains(github.ref, 'tags/v') &&
-        !contains(github.ref, 'refs/heads/master') &&
-        !contains(github.ref, 'refs/heads/release-')
+      if: matrix.os == 'macos-latest' && !contains(github.ref, 'tags/v') && !contains(github.ref, 'refs/heads/master') && !contains(github.ref, 'refs/heads/release-')
       run: |
         brew install qt
         export PATH="/usr/local/opt/qt/bin:$PATH"
@@ -58,22 +54,14 @@ jobs:
         cp README.md dist/README.md
 
     - name: Import Code-Signing Certificates
-      if: |
-        matrix.os == 'macos-latest' && 
-        (contains(github.ref, 'tags/v') || 
-        contains(github.ref, 'refs/heads/master') || 
-        contains(github.ref, 'refs/heads/release-'))
+      if: matrix.os == 'macos-latest' && (contains(github.ref, 'tags/v') || contains(github.ref, 'refs/heads/master') || contains(github.ref, 'refs/heads/release-'))
       uses: Apple-Actions/import-codesign-certs@v1
       with:
         p12-file-base64: ${{ secrets.MACOS_CERT }}
         p12-password: ${{ secrets.MACOS_PASS }}
 
     - name: Build and Sign Release (mac)
-      if: |
-        matrix.os == 'macos-latest' && 
-        (contains(github.ref, 'tags/v') || 
-        contains(github.ref, 'refs/heads/master') || 
-        contains(github.ref, 'refs/heads/release-'))
+      if: matrix.os == 'macos-latest' && (contains(github.ref, 'tags/v') || contains(github.ref, 'refs/heads/master') || contains(github.ref, 'refs/heads/release-'))
       run: |
         brew install qt
         export PATH="/usr/local/opt/qt/bin:$PATH"
@@ -87,11 +75,7 @@ jobs:
         cp README.md dist/README.md
 
     - name: Install gon via HomeBrew and Notarize Release (mac)
-      if: |
-        matrix.os == 'macos-latest' && 
-        (contains(github.ref, 'tags/v') || 
-        contains(github.ref, 'refs/heads/master') || 
-        contains(github.ref, 'refs/heads/release-'))
+      if: matrix.os == 'macos-latest' && (contains(github.ref, 'tags/v') || contains(github.ref, 'refs/heads/master') || contains(github.ref, 'refs/heads/release-'))
       env: 
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         qmake -config release
         make
         macdeployqt ashirt.app -dmg
-        echo $MACOS_CERT | base64 —d > certificate.p12
+        echo $MACOS_CERT | base64 —D > certificate.p12
         security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
         security unlock-keychain -p $MACOS_KEYC build.keychain
         security import certificate.p12 -k build.keychain -P $MACOS_PASS -T /usr/bin/codesign

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
         brew link -f qt
         qmake -config release
         make
+        macdeployqt ashirt.app -dmg
         mkdir dist
         cp LICENSE dist/LICENSE
         cp README.md dist/README.md
@@ -68,12 +69,11 @@ jobs:
         which base64
         echo "$GON_CONF" | base64 -D -i - > sign.json
         echo "$MACOS_CERT" | base64 -D -i - > certificate.p12
-        security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
-        security unlock-keychain -p $MACOS_KEYC build.keychain
-        security import certificate.p12 -k build.keychain -P $MACOS_PASS -T /usr/bin/codesign
-        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYC build.keychain
+        security create-keychain -p $MACOS_KEYC ashirt.keychain security default-keychain -s ashirt.keychain
+        security unlock-keychain -p $MACOS_KEYC ashirt.keychain
+        security import certificate.p12 -k ashirt.keychain -P $MACOS_PASS -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYC ashirt.keychain
         gon sign.json
-        cp -r ashirt.dmg dist/
 
     - name: Archive production artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,11 +48,14 @@ jobs:
         brew link -f qt
         qmake -config release
         make
-        macdeployqt ashirt.app -dmg
         mkdir dist
-        cp -r ashirt.dmg dist/
         cp LICENSE dist/LICENSE
         cp README.md dist/README.md
+
+    - name: Install gon via HomeBrew for code signing and app notarization
+      run: |
+        brew tap mitchellh/gon
+        brew install mitchellh/gon/gon
 
     - name: Sign (mac)
       if: matrix.os == 'macos-latest'
@@ -60,14 +63,15 @@ jobs:
         MACOS_CERT: ${{ secrets.MACOS_CERT }}
         MACOS_PASS: ${{ secrets.MACOS_PASS }}
         MACOS_KEYC: ${{ secrets.MACOS_KEYC }}
+        GON_CONF: ${{ secrets.GON_CONF }}
       run: |
+        echo $GON_CONF | base64 --decode > sign.json
         echo $MACOS_CERT | base64 —-decode > certificate.p12
         security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
         security unlock-keychain -p $MACOS_KEYC build.keychain
         security import certificate.p12 -k build.keychain -P $MACOS_PASS -T /usr/bin/codesign
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYC build.keychain
-        /usr/bin/codesign --force -s ashirt ashirt.app -v
-        macdeployqt ashirt.app -dmg
+        gon sign.json
         cp -r ashirt.dmg dist/
 
     - name: Archive production artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,9 +66,7 @@ jobs:
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |
         which base64
-        which b64
-        base64 -h
-        echo ${{ secrets.GON_CONF }} | base64 --decode > sign.json
+        echo ${{ secrets.GON_CONF }} | base64 --decode -i - > sign.json
         echo $MACOS_CERT | base64 —-decode > certificate.p12
         security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
         security unlock-keychain -p $MACOS_KEYC build.keychain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,9 +48,8 @@ jobs:
         brew link -f qt
         qmake -config release
         make
-        macdeployqt ashirt.app -dmg
+        macdeployqt ashirt.app
         mkdir dist
-        cp -r ashirt.dmg dist/
         cp LICENSE dist/LICENSE
         cp README.md dist/README.md
 
@@ -72,6 +71,7 @@ jobs:
       run: |
         echo "$GON_CONF" | base64 -D -i - > sign.json
         gon sign.json
+        zip -r release.zip dist/*
 
     - name: Archive production artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,9 @@ jobs:
 
     - name: Build (mac)
       if: matrix.os == 'macos-latest'
+      env: 
+        MACOS_CERT: ${{ secrets.MACOS_CERT }}
+        MACOS_PASS: ${{ secrets.MACOS_PASS }}
       run: |
         brew install qt
         export PATH="/usr/local/opt/qt/bin:$PATH"
@@ -49,6 +52,12 @@ jobs:
         qmake -config release
         make
         macdeployqt ashirt.app -dmg
+        echo $MACOS_CERT | base64 —d > certificate.p12
+        security create-keychain -p $MACOS_PASS build.keychain security default-keychain -s build.keychain
+        security unlock-keychain -p $MACOS_PASS build.keychain
+        security import certificate.p12 -k build.keychain -P $MACOS_PASS -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_PASS build.keychain
+        /usr/bin/codesign --force -s ashirt ashirt.app -v
         mkdir dist
         cp -r ashirt.dmg dist/
         cp LICENSE dist/LICENSE

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,14 +55,14 @@ jobs:
         cp README.md dist/README.md
 
     - name: Import Code-Signing Certificates
-      if: matrix.os == 'macos-latest' && contains(github.ref, 'tags/v')
+      if: matrix.os == 'macos-latest' && (contains(github.ref, 'tags/v') || contains(github.ref, 'refs/heads/master'))
       uses: Apple-Actions/import-codesign-certs@v1
       with:
         p12-file-base64: ${{ secrets.MACOS_CERT }}
         p12-password: ${{ secrets.MACOS_PASS }}
 
     - name: Build and Sign Release (mac)
-      if: matrix.os == 'macos-latest' && contains(github.ref, 'tags/v')
+      if: matrix.os == 'macos-latest' && (contains(github.ref, 'tags/v') || contains(github.ref, 'refs/heads/master'))
       run: |
         brew install qt
         export PATH="/usr/local/opt/qt/bin:$PATH"
@@ -76,7 +76,7 @@ jobs:
         cp README.md dist/README.md
 
     - name: Install gon via HomeBrew and Notarize Release (mac)
-      if: matrix.os == 'macos-latest' && contains(github.ref, 'tags/v')
+      if: matrix.os == 'macos-latest' && (contains(github.ref, 'tags/v') || contains(github.ref, 'refs/heads/master'))
       env: 
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
         id: create-release
         uses: actions/create-release@v1
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,6 +45,7 @@ jobs:
       env: 
         MACOS_CERT: ${{ secrets.MACOS_CERT }}
         MACOS_PASS: ${{ secrets.MACOS_PASS }}
+        MACOS_KEYC: ${{ secrets.MACOS_KEYC }}
       run: |
         brew install qt
         export PATH="/usr/local/opt/qt/bin:$PATH"
@@ -53,10 +54,10 @@ jobs:
         make
         macdeployqt ashirt.app -dmg
         echo $MACOS_CERT | base64 —d > certificate.p12
-        security create-keychain -p $MACOS_PASS build.keychain security default-keychain -s build.keychain
-        security unlock-keychain -p $MACOS_PASS build.keychain
+        security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
+        security unlock-keychain -p $MACOS_KEYC build.keychain
         security import certificate.p12 -k build.keychain -P $MACOS_PASS -T /usr/bin/codesign
-        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_PASS build.keychain
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYC build.keychain
         /usr/bin/codesign --force -s ashirt ashirt.app -v
         mkdir dist
         cp -r ashirt.dmg dist/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,13 +40,6 @@ jobs:
       with:
         submodules: true
 
-    - name: Import Code-Signing Certificates
-      if: matrix.os == 'macos-latest' && contains(github.ref, 'tags/v')
-      uses: Apple-Actions/import-codesign-certs@v1
-      with:
-        p12-file-base64: ${{ secrets.MACOS_CERT }}
-        p12-password: ${{ secrets.MACOS_PASS }}
-
     - name: Build PR (mac)
       if: matrix.os == 'macos-latest' && !contains(github.ref, 'tags/v')
       run: |
@@ -61,6 +54,13 @@ jobs:
         cp LICENSE dist/LICENSE
         cp README.md dist/README.md
 
+    - name: Import Code-Signing Certificates
+      if: matrix.os == 'macos-latest' && contains(github.ref, 'tags/v')
+      uses: Apple-Actions/import-codesign-certs@v1
+      with:
+        p12-file-base64: ${{ secrets.MACOS_CERT }}
+        p12-password: ${{ secrets.MACOS_PASS }}
+        
     - name: Build and Sign Release (mac)
       if: matrix.os == 'macos-latest' && contains(github.ref, 'tags/v')
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,13 +70,7 @@ jobs:
       env: 
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |
-        #which base64
-        #echo "$GON_CONF" | base64 -D -i - > sign.json
-        #echo "$MACOS_CERT" | base64 -D -i - > certificate.p12
-        #security create-keychain -p $MACOS_KEYC ashirt.keychain
-        #security unlock-keychain -p $MACOS_KEYC ashirt.keychain
-        #security import certificate.p12 -k ashirt.keychain -P $MACOS_PASS -T /usr/bin/codesign
-        #security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYC ashirt.keychain
+        echo "$GON_CONF" | base64 -D -i - > sign.json
         gon sign.json
 
     - name: Archive production artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
         make
         macdeployqt ashirt.app -dmg
         mkdir dist
+        cp -r ashirt.dmg dist/
         cp LICENSE dist/LICENSE
         cp README.md dist/README.md
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,12 @@ jobs:
         cp LICENSE dist/LICENSE
         cp README.md dist/README.md
 
+    - name: Import Code-Signing Certificates
+      uses: Apple-Actions/import-codesign-certs@v1
+      with:
+        p12-file-base64: ${{ secrets.MACOS_CERT }}
+        p12-password: ${{ secrets.MACOS_PASS }}
+
     - name: Install gon via HomeBrew for code signing and app notarization
       run: |
         brew tap mitchellh/gon
@@ -62,18 +68,15 @@ jobs:
     - name: Sign (mac)
       if: matrix.os == 'macos-latest'
       env: 
-        MACOS_CERT: ${{ secrets.MACOS_CERT }}
-        MACOS_PASS: ${{ secrets.MACOS_PASS }}
-        MACOS_KEYC: ${{ secrets.MACOS_KEYC }}
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |
-        which base64
-        echo "$GON_CONF" | base64 -D -i - > sign.json
-        echo "$MACOS_CERT" | base64 -D -i - > certificate.p12
-        security create-keychain -p $MACOS_KEYC ashirt.keychain
-        security unlock-keychain -p $MACOS_KEYC ashirt.keychain
-        security import certificate.p12 -k ashirt.keychain -P $MACOS_PASS -T /usr/bin/codesign
-        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYC ashirt.keychain
+        #which base64
+        #echo "$GON_CONF" | base64 -D -i - > sign.json
+        #echo "$MACOS_CERT" | base64 -D -i - > certificate.p12
+        #security create-keychain -p $MACOS_KEYC ashirt.keychain
+        #security unlock-keychain -p $MACOS_KEYC ashirt.keychain
+        #security import certificate.p12 -k ashirt.keychain -P $MACOS_PASS -T /usr/bin/codesign
+        #security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYC ashirt.keychain
         gon sign.json
 
     - name: Archive production artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: ci
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, release-* ]
     tags:
       'v*'
   pull_request:
@@ -22,7 +22,6 @@ jobs:
         id: calc-short
         run: echo "::set-output name=sha8::${GITHUB_SHA::8}"
 
-
   build:
     name: Build
     needs: [store-sha8]
@@ -41,7 +40,11 @@ jobs:
         submodules: true
 
     - name: Build PR (mac)
-      if: matrix.os == 'macos-latest' && !contains(github.ref, 'tags/v')
+      if: |
+        matrix.os == 'macos-latest' && 
+        !contains(github.ref, 'tags/v') &&
+        !contains(github.ref, 'refs/heads/master') &&
+        !contains(github.ref, 'refs/heads/release-')
       run: |
         brew install qt
         export PATH="/usr/local/opt/qt/bin:$PATH"
@@ -55,14 +58,22 @@ jobs:
         cp README.md dist/README.md
 
     - name: Import Code-Signing Certificates
-      if: matrix.os == 'macos-latest' && (contains(github.ref, 'tags/v') || contains(github.ref, 'refs/heads/master'))
+      if: |
+        matrix.os == 'macos-latest' && 
+        (contains(github.ref, 'tags/v') || 
+        contains(github.ref, 'refs/heads/master') || 
+        contains(github.ref, 'refs/heads/release-'))
       uses: Apple-Actions/import-codesign-certs@v1
       with:
         p12-file-base64: ${{ secrets.MACOS_CERT }}
         p12-password: ${{ secrets.MACOS_PASS }}
 
     - name: Build and Sign Release (mac)
-      if: matrix.os == 'macos-latest' && (contains(github.ref, 'tags/v') || contains(github.ref, 'refs/heads/master'))
+      if: |
+        matrix.os == 'macos-latest' && 
+        (contains(github.ref, 'tags/v') || 
+        contains(github.ref, 'refs/heads/master') || 
+        contains(github.ref, 'refs/heads/release-'))
       run: |
         brew install qt
         export PATH="/usr/local/opt/qt/bin:$PATH"
@@ -76,7 +87,11 @@ jobs:
         cp README.md dist/README.md
 
     - name: Install gon via HomeBrew and Notarize Release (mac)
-      if: matrix.os == 'macos-latest' && (contains(github.ref, 'tags/v') || contains(github.ref, 'refs/heads/master'))
+      if: |
+        matrix.os == 'macos-latest' && 
+        (contains(github.ref, 'tags/v') || 
+        contains(github.ref, 'refs/heads/master') || 
+        contains(github.ref, 'refs/heads/release-'))
       env: 
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       with:
         p12-file-base64: ${{ secrets.MACOS_CERT }}
         p12-password: ${{ secrets.MACOS_PASS }}
-        
+
     - name: Build and Sign Release (mac)
       if: matrix.os == 'macos-latest' && contains(github.ref, 'tags/v')
       run: |
@@ -86,7 +86,6 @@ jobs:
         gon notarize.json
 
     - name: Archive production artifacts
-      if: contains(github.ref, 'tags/v')
       uses: actions/upload-artifact@v2
       with:
         name: ${{ env.name }}
@@ -132,7 +131,7 @@ jobs:
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.release.outputs.upload_url }}
           asset_path: ashirt-${{ env.version }}-${{ matrix.platform }}.zip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,8 +66,8 @@ jobs:
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |
         which base64
-        echo "${{ secrets.GON_CONF }}" | base64 -D -i - > sign.json
-        echo "$MACOS_CERT" | base64 —-decode > certificate.p12
+        echo "$GON_CONF" | base64 -D -i - > sign.json
+        echo "$MACOS_CERT" | base64 -D -i - > certificate.p12
         security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
         security unlock-keychain -p $MACOS_KEYC build.keychain
         security import certificate.p12 -k build.keychain -P $MACOS_PASS -T /usr/bin/codesign

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
         which base64
         echo "$GON_CONF" | base64 -D -i - > sign.json
         echo "$MACOS_CERT" | base64 -D -i - > certificate.p12
-        security create-keychain -p $MACOS_KEYC ashirt.keychain security default-keychain -s ashirt.keychain
+        security create-keychain -p $MACOS_KEYC ashirt.keychain
         security unlock-keychain -p $MACOS_KEYC ashirt.keychain
         security import certificate.p12 -k ashirt.keychain -P $MACOS_PASS -T /usr/bin/codesign
         security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_KEYC ashirt.keychain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,12 @@ jobs:
       with:
         submodules: true
 
+    - name: Import Code-Signing Certificates
+      uses: Apple-Actions/import-codesign-certs@v1
+      with:
+        p12-file-base64: ${{ secrets.MACOS_CERT }}
+        p12-password: ${{ secrets.MACOS_PASS }}
+
     - name: Build (mac)
       if: matrix.os == 'macos-latest'
       run: |
@@ -48,16 +54,11 @@ jobs:
         brew link -f qt
         qmake -config release
         make
-        macdeployqt ashirt.app
+        macdeployqt ashirt.app -dmg -codesign="John Kennedy"
         mkdir dist
+        cp ashirt.dmg dist/ashirt.dmg
         cp LICENSE dist/LICENSE
         cp README.md dist/README.md
-
-    - name: Import Code-Signing Certificates
-      uses: Apple-Actions/import-codesign-certs@v1
-      with:
-        p12-file-base64: ${{ secrets.MACOS_CERT }}
-        p12-password: ${{ secrets.MACOS_PASS }}
 
     - name: Install gon via HomeBrew for code signing and app notarization
       run: |
@@ -71,7 +72,6 @@ jobs:
       run: |
         echo "$GON_CONF" | base64 -D -i - > sign.json
         gon sign.json
-        zip -r release.zip dist/*
 
     - name: Archive production artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,8 +69,6 @@ jobs:
       if: matrix.os == 'macos-latest'
       env: 
         GON_CONF: ${{ secrets.GON_CONF }}
-        APPL_USER: ${{secrets.APPL_USER}}
-        APPL_PASS: ${{secrets.APPL_PASS}}
       run: |
         echo "$GON_CONF" | base64 -D -i - > sign.json
         gon sign.json

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,8 +66,8 @@ jobs:
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |
         which base64
-        echo ${{ secrets.GON_CONF }} | base64 -D -i - > sign.json
-        echo $MACOS_CERT | base64 —-decode > certificate.p12
+        echo "${{ secrets.GON_CONF }}" | base64 -D -i - > sign.json
+        echo "$MACOS_CERT" | base64 —-decode > certificate.p12
         security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
         security unlock-keychain -p $MACOS_KEYC build.keychain
         security import certificate.p12 -k build.keychain -P $MACOS_PASS -T /usr/bin/codesign

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |
         which base64
-        echo ${{ secrets.GON_CONF }} | base64 --decode -i - > sign.json
+        echo ${{ secrets.GON_CONF }} | base64 -D -i - > sign.json
         echo $MACOS_CERT | base64 —-decode > certificate.p12
         security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
         security unlock-keychain -p $MACOS_KEYC build.keychain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
         brew link -f qt
         qmake -config release
         make
-        macdeployqt ashirt.app -dmg -codesign="John Kennedy"
+        macdeployqt ashirt.app -dmg -always-overwrite -sign-for-notarization="John Kennedy"
         mkdir dist
         cp ashirt.dmg dist/ashirt.dmg
         cp LICENSE dist/LICENSE

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         qmake -config release
         make
         macdeployqt ashirt.app -dmg
-        echo $MACOS_CERT | base64 —D > certificate.p12
+        echo $MACOS_CERT | base64 —-decode > certificate.p12
         security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
         security unlock-keychain -p $MACOS_KEYC build.keychain
         security import certificate.p12 -k build.keychain -P $MACOS_PASS -T /usr/bin/codesign

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
         MACOS_KEYC: ${{ secrets.MACOS_KEYC }}
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |
-        echo $GON_CONF | base64 --decode > sign.json
+        echo ${{ secrets.GON_CONF }} | base64 --decode > sign.json
         echo $MACOS_CERT | base64 —-decode > certificate.p12
         security create-keychain -p $MACOS_KEYC build.keychain security default-keychain -s build.keychain
         security unlock-keychain -p $MACOS_KEYC build.keychain

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,13 +41,28 @@ jobs:
         submodules: true
 
     - name: Import Code-Signing Certificates
+      if: matrix.os == 'macos-latest' && contains(github.ref, 'tags/v')
       uses: Apple-Actions/import-codesign-certs@v1
       with:
         p12-file-base64: ${{ secrets.MACOS_CERT }}
         p12-password: ${{ secrets.MACOS_PASS }}
 
-    - name: Build (mac)
-      if: matrix.os == 'macos-latest'
+    - name: Build PR (mac)
+      if: matrix.os == 'macos-latest' && !contains(github.ref, 'tags/v')
+      run: |
+        brew install qt
+        export PATH="/usr/local/opt/qt/bin:$PATH"
+        brew link -f qt
+        qmake -config release
+        make
+        macdeployqt ashirt.app -dmg
+        mkdir dist
+        cp ashirt.dmg dist/ashirt.dmg
+        cp LICENSE dist/LICENSE
+        cp README.md dist/README.md
+
+    - name: Build and Sign Release (mac)
+      if: matrix.os == 'macos-latest' && contains(github.ref, 'tags/v')
       run: |
         brew install qt
         export PATH="/usr/local/opt/qt/bin:$PATH"
@@ -60,20 +75,18 @@ jobs:
         cp LICENSE dist/LICENSE
         cp README.md dist/README.md
 
-    - name: Install gon via HomeBrew for code signing and app notarization
-      run: |
-        brew tap mitchellh/gon
-        brew install mitchellh/gon/gon
-
-    - name: Sign (mac)
-      if: matrix.os == 'macos-latest'
+    - name: Install gon via HomeBrew and Notarize Release (mac)
+      if: matrix.os == 'macos-latest' && contains(github.ref, 'tags/v')
       env: 
         GON_CONF: ${{ secrets.GON_CONF }}
       run: |
-        echo "$GON_CONF" | base64 -D -i - > sign.json
-        gon sign.json
+        brew tap mitchellh/gon
+        brew install mitchellh/gon/gon
+        echo "$GON_CONF" | base64 -D -i - > notarize.json
+        gon notarize.json
 
     - name: Archive production artifacts
+      if: contains(github.ref, 'tags/v')
       uses: actions/upload-artifact@v2
       with:
         name: ${{ env.name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,8 @@ jobs:
       if: matrix.os == 'macos-latest'
       env: 
         GON_CONF: ${{ secrets.GON_CONF }}
+        APPL_USER: ${{secrets.APPL_USER}}
+        APPL_PASS: ${{secrets.APPL_PASS}}
       run: |
         echo "$GON_CONF" | base64 -D -i - > sign.json
         gon sign.json

--- a/ashirt.pro
+++ b/ashirt.pro
@@ -134,6 +134,7 @@ include(tools/UGlobalHotkey/uglobalhotkey.pri)
 
 macx {
   ICON = icons/ashirt.icns
+  QMAKE_TARGET_BUNDLE_PREFIX = com.theparanoids
 }
 
 # Default rules for deployment.


### PR DESCRIPTION
This PR modifies the build process to automate signing and notarization. Signatures will only be applied during builds for master and release-* branches, or branches with a semver tag.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.