### PR TITLE
Set AShirt organization to "ashirt" (windows only)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,10 @@ int main(int argc, char* argv[]) {
   QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
   QCoreApplication::setApplicationName("ashirt");
 
+#ifdef Q_OS_WIN
+  QCoreApplication::setOrganizationName("ashirt");
+#endif
+
   DatabaseConnection* conn;
   try {
     conn = new DatabaseConnection(Constants::dbLocation(), Constants::defaultDbName());


### PR DESCRIPTION
This PR provides an organization named `ashirt` for windows computers. This is done so that QSettings properly records the values in the windows registery (otherwise, saving settings results in an access error). 
This was avoided for Macos and Linux because it would result in  users losing their app settings.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.