### PR TITLE
Locking to qt 5.15.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
     - name: Build PR (mac)
       if: matrix.os == 'macos-latest' && !contains(github.ref, 'tags/v') && !contains(github.ref, 'refs/heads/master') && !contains(github.ref, 'refs/heads/release-')
       run: |
-        brew install qt
+        brew install qt@5
         export PATH="/usr/local/opt/qt/bin:$PATH"
         brew link -f qt
         qmake -config release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
       run: |
         brew install qt@5
         export PATH="/usr/local/opt/qt@5/bin:$PATH"
-        brew link -f qt
+        brew link -f qt@5
         qmake -config release
         make
         macdeployqt ashirt.app -dmg

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       if: matrix.os == 'macos-latest' && !contains(github.ref, 'tags/v') && !contains(github.ref, 'refs/heads/master') && !contains(github.ref, 'refs/heads/release-')
       run: |
         brew install qt@5
-        export PATH="/usr/local/opt/qt/bin:$PATH"
+        export PATH="/usr/local/opt/qt@5/bin:$PATH"
         brew link -f qt
         qmake -config release
         make


### PR DESCRIPTION
Brew has finally released qt6 formulae, so we must lock to 5.15.2 until we migrate to qt6.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.