### PR TITLE
Lock to qt5 in alternate step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,9 +71,9 @@ jobs:
         matrix.os == 'macos-latest' &&
         (contains(github.ref, 'tags/v') || github.ref == 'refs/heads/master' || contains(github.ref, 'refs/heads/release'))
       run: |
-        brew install qt
-        export PATH="/usr/local/opt/qt/bin:$PATH"
-        brew link -f qt
+        brew install qt@5
+        export PATH="/usr/local/opt/qt@5/bin:$PATH"
+        brew link -f qt@5
         qmake -config release
         make
         macdeployqt ashirt.app -dmg -always-overwrite -sign-for-notarization="John Kennedy"


### PR DESCRIPTION
This PR fixes the alternate build step from the merge of #78 and #83. Lock to qt@5 is now applied to the signed build steps as intended.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.