### PR TITLE
Support editing of evidence description/tags when unsubmitted

### DIFF
--- a/src/components/evidence_editor/evidenceeditor.cpp
+++ b/src/components/evidence_editor/evidenceeditor.cpp
@@ -145,6 +145,13 @@ void EvidenceEditor::loadData() {
   splitter->insertWidget(0, loadedPreview);
 }
 
+void EvidenceEditor::revert() {
+  tagEditor->clear();
+  originalEvidenceData = db->getEvidenceDetails(evidenceID);
+  descriptionTextBox->setText(originalEvidenceData.description);
+  tagEditor->loadTags(operationSlug, originalEvidenceData.tags);
+}
+
 void EvidenceEditor::updateEvidence(qint64 evidenceID, bool readonly) {
   clearEditor();
   setEnabled(false);

--- a/src/components/evidence_editor/evidenceeditor.cpp
+++ b/src/components/evidence_editor/evidenceeditor.cpp
@@ -116,7 +116,6 @@ void EvidenceEditor::wireUi() {
 void EvidenceEditor::loadData() {
   // get local db evidence data
   clearEditor();
-  delete loadedPreview;
   try {
     originalEvidenceData = db->getEvidenceDetails(evidenceID);
     descriptionTextBox->setText(originalEvidenceData.description);

--- a/src/components/evidence_editor/evidenceeditor.h
+++ b/src/components/evidence_editor/evidenceeditor.h
@@ -42,6 +42,10 @@ class EvidenceEditor : public QWidget {
   /// file location of the provided evidence IDs
   std::vector<DeleteEvidenceResponse> deleteEvidence(std::vector<qint64> evidenceIDs);
 
+  /// revert re-loads the evidence to restore the content to the saved version.
+  /// Only useful when used in the evidence manager.
+  void revert();
+
  signals:
   void onWidgetReady();
 

--- a/src/components/tagging/tageditor.cpp
+++ b/src/components/tagging/tageditor.cpp
@@ -199,6 +199,7 @@ void TagEditor::onCreateTagComplete() {
     auto newTag = dto::Tag::parseData(data);
     addTag(newTag);
     tagView->addTag(newTag);
+    tagCache->requestExpiry(this->operationSlug);
     updateCompleterModel();
   }
   else {

--- a/src/components/tagging/tageditor.cpp
+++ b/src/components/tagging/tageditor.cpp
@@ -147,6 +147,7 @@ void TagEditor::loadTags(const QString &operationSlug, std::vector<model::Tag> i
 
 void TagEditor::tagsUpdated(QString operationSlug, std::vector<dto::Tag> tags) {
   if (this->operationSlug == operationSlug) {
+    clearTags();
     for (auto tag : tags) {
       addTag(tag);
 
@@ -215,6 +216,11 @@ void TagEditor::onCreateTagComplete() {
 void TagEditor::addTag(dto::Tag tag) {
   tagNames << tag.name;
   tagMap.emplace(standardizeTagKey(tag.name), tag);
+}
+
+void TagEditor::clearTags() {
+  tagNames.clear();
+  tagMap.clear();
 }
 
 QString TagEditor::standardizeTagKey(const QString& tagName) {

--- a/src/components/tagging/tageditor.h
+++ b/src/components/tagging/tageditor.h
@@ -34,6 +34,7 @@ class TagEditor : public QWidget {
   void tagTextEntered(QString text);
   inline void showCompleter() { completer->complete(); }
   void addTag(dto::Tag tag);
+  void clearTags();
   QString standardizeTagKey(const QString &tagName);
 
  private slots:

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -202,7 +202,7 @@ void EvidenceManager::wireUi() {
 }
 
 void EvidenceManager::editEvidenceButtonClicked() {
-  if( editButton->text() == "Save") {
+  if(editButton->text() == "Save") {
     evidenceEditor->saveEvidence();
     cancelEditEvidenceButtonClicked();
     refreshRow(evidenceTable->currentRow());

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -116,6 +116,14 @@ void EvidenceManager::buildUi() {
   cancelEditButton = new QPushButton("Cancel", this);
   cancelEditButton->setVisible(false);
 
+  // remove button defaults (i.e. enter-submits-form functionality)
+  editFiltersButton->setAutoDefault(false);
+  applyFilterButton->setAutoDefault(false);
+  resetFilterButton->setAutoDefault(false);
+  editButton->setAutoDefault(false);
+  cancelEditButton->setAutoDefault(false);
+
+  // apply a default for apply-filter, which is the typical action
   applyFilterButton->setDefault(true);
 
   buildEvidenceTableUi();
@@ -206,8 +214,12 @@ void EvidenceManager::editEvidenceButtonClicked() {
     evidenceEditor->saveEvidence();
     cancelEditEvidenceButtonClicked();
     refreshRow(evidenceTable->currentRow());
+    // restore default form action
+    applyFilterButton->setDefault(true);
   }
   else {
+    // remove default form action to prevent accidental reloading of evidence
+    applyFilterButton->setDefault(false);
     evidenceEditor->setEnabled(true);
     editButton->setText("Save");
     cancelEditButton->setVisible(true);

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -231,6 +231,7 @@ void EvidenceManager::cancelEditEvidenceButtonClicked() {
   cancelEditButton->setVisible(false);
   //refreshRow(evidenceTable->currentRow());
   editButton->setText("Edit");
+  evidenceEditor->revert();
 }
 
 void EvidenceManager::showEvent(QShowEvent* evt) {

--- a/src/forms/evidence/evidencemanager.h
+++ b/src/forms/evidence/evidencemanager.h
@@ -88,6 +88,13 @@ class EvidenceManager : public QDialog {
   void resetFilterButtonClicked();
   /// deleteAllTriggered recieves the triggered event from the delete table action
   void deleteAllTriggered();
+
+  /// editEvidenceButtonClicked saves (but does not submit) the evidence currently being edited.
+  /// After saving, the edit/cancel button is reset. Note: this will change the name of the button to "Save"
+  void editEvidenceButtonClicked();
+
+  /// cancelEditEvidenceButtonClicked resets the edit/cancel buttons 
+  void cancelEditEvidenceButtonClicked();
   
   /// deleteSet is a small helper to iterate through the provided list, delete the ids, and process
   /// the result
@@ -129,6 +136,8 @@ class EvidenceManager : public QDialog {
   QPushButton* editFiltersButton = nullptr;
   QPushButton* applyFilterButton = nullptr;
   QPushButton* resetFilterButton = nullptr;
+  QPushButton* editButton = nullptr;
+  QPushButton* cancelEditButton = nullptr;
   QLineEdit* filterTextBox = nullptr;
   QTableWidget* evidenceTable = nullptr;
   EvidenceEditor* evidenceEditor = nullptr;


### PR DESCRIPTION
This PR adds the ability to edit evidence before the user submits, when the user initially is unable to save evidence.

Note: this does not submit the evidence, only saves it. We can tack on submitting as well, if desired.

Known Issues:
* selecting multiple pieces of evidence and then choosing a single row that is editable will not enable the edit button
  * This is due to how these events fire. The row count appears to be larger than it is when reloading a row in these cases. Not sure if this is fixable.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.