### PR TITLE
Remove need to parse operation id

### DIFF
--- a/src/dtos/operation.h
+++ b/src/dtos/operation.h
@@ -28,7 +28,6 @@ class Operation {
   QString name;
   int numUsers;
   OperationStatus status;
-  qint64 id;
 
   static Operation parseData(QByteArray data) {
     return parseJSONItem<Operation>(data, Operation::fromJson);
@@ -57,7 +56,6 @@ class Operation {
     o.name = obj["name"].toString();
     o.numUsers = obj["numUsers"].toInt();
     o.status = static_cast<OperationStatus>(obj["status"].toInt());
-    o.id = obj["id"].toVariant().toLongLong();
 
     return o;
   }


### PR DESCRIPTION
AShirt currently parses the operation ID provided by ashirt server when getting a list of operations (and other times). This field was parsed, but is actually not used. This PR removes the parsing so that ashirt server can opt not to send this value.

As an aside, all operation interaction is done via operation slugs, rather than IDs.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.