### PR TITLE
Initial CMake Building

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,72 +23,110 @@ jobs:
         run: echo "::set-output name=sha8::${GITHUB_SHA::8}"
 
   build:
-    name: Build
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
     needs: [store-sha8]
     strategy:
-      matrix:
-        os: [macos-latest, ubuntu-16.04]
-        qt-version: ['5.15.2']
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+      matrix:
+        config:
+        - {
+         name: "Linux-Qt5"
+            , os: ubuntu-20.04
+            , QT_VERSION: 5.15.2 , QT_INST_DIR: /opt
+            , QT_STRING: "Qt5"
+            , extraCMakeConfig: "-DCMAKE_INSTALL_PREFIX=/usr -DQT_DEFAULT_MAJOR_VERSION=5"
+          }
+        - {
+            name: "Linux-Qt6"
+            , os: ubuntu-20.04
+            , QT_VERSION: 6.2.4, QT_INST_DIR: /opt
+            , QT_STRING: "Qt6"
+            , extraCMakeConfig: "-DCMAKE_INSTALL_PREFIX=/usr -DQT_DEFAULT_MAJOR_VERSION=6"
+            , linuxDeployQtPath: "export PATH=$PATH:/opt/Qt/6.2.4/gcc_64/libexec"
 
+          }
+        - {
+            name: "Mac-Qt5"
+            , os: macos-latest
+            , QT_VERSION: 5.15.2 , QT_INST_DIR: /Users/runner
+            , QT_STRING: "Qt5"
+            , extraCMakeConfig: "-DQT_DEFAULT_MAJOR_VERSION=5"
+          }
+        - {
+            name: "Mac-Qt6"
+            , os: macos-latest
+            , QT_VERSION: 6.2.4 , QT_INST_DIR: /Users/runner
+            , QT_STRING: "Qt6"
+            , extraCMakeConfig: "-DQT_DEFAULT_MAJOR_VERSION=6"
+          }
     steps:
     - name: Set artifact name
-      run: echo "name=ashirt-${{ needs.store-sha8.outputs.sha8 }}-$(uname -s | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      run: echo "name=ashirt-${{ needs.store-sha8.outputs.sha8 }}-${{matrix.config.QT_STRING}}-$(uname -s | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
     - name: Check out code
-      uses: actions/checkout@v2.4.0 
+      uses: actions/checkout@v3
       with:
         submodules: true
+        fetch-depth: 0
+    - run: git fetch --tags --force
 
     - name: Cache Qt
-      if: matrix.os == 'ubuntu-16.04' # We might want to do this for both mac and linux
       id: cache-qt
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v2
       with:
-        path: ../Qt
-        key: ${{ runner.os }}-QtCache-${{ matrix.qt-version }}
+        path: ${{matrix.config.QT_INST_DIR}}/Qt
+        key: ${{ runner.os }}${{ matrix.config.WIN_ARCH }}-qt-${{ matrix.config.QT_VERSION }}
 
-    - name: Install Qt on Linux  # we can also use this for macs
-      if: matrix.os == 'ubuntu-16.04'
-      uses: jurplel/install-qt-action@v2
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2.14.0
       with:
-        version: ${{ matrix.qt-version }}
-        cached: ${{ steps.cache-qt.outputs.cache-hit }}
+       aqtversion: ==2.0.0
+       py7zrversion: ==0.16.2
+       dir: ${{matrix.config.QT_INST_DIR}}
+       arch: ${{ matrix.config.QT_ARCH }}
+       version: ${{ matrix.config.QT_VERSION }}
+       cached: ${{ steps.cache-qt.outputs.cache-hit }}
 
-    - name: Build Pr (Linux)
-      if: matrix.os == 'ubuntu-16.04' && !contains(github.ref, 'tags/v') && !contains(github.ref, 'refs/heads/main') && !contains(github.ref, 'refs/heads/release-')
+    - name: Install Dependencies
+      if: (runner.os == 'Windows') || (runner.os == 'Linux')
+      shell: bash
       run: |
-        echo "Building!"
-        sudo apt install libxcb-keysyms1-dev desktop-file-utils libxcb-icccm4 libxcb-image0 libxcb-util1 \
-                         libxcb-render-util0 libxcb-xinerama0 libxcb-composite0 libxcb-cursor0 libxcb-damage0 \
-                         libxcb-dpms0 libxcb-dri2-0 libxcb-dri3-0 libxcb-ewmh2 libxcb-glx0 libxcb-present0 \
-                         libxcb-randr0 libxcb-record0 libxcb-render0 libxcb-res0 libxcb-screensaver0 \
-                         libxcb-shape0 libxcb-shm0 libxcb-sync1 
-        qmake PREFIX=/usr -config release
-        make -j2
+        if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get update > /dev/null && sudo apt-get install -qqq libxcb-keysyms1-dev libxkbcommon-dev > /dev/null
+        elif [ "$RUNNER_OS" == "Windows" ]; then
+            choco install ninja --ignore-checksums
+        fi
 
-        # create app image
-        make INSTALL_ROOT=appdir -j2 install ; find appdir/
-        wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
-        chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+    - name: Build
+      run: |
+        cmake -DCMAKE_BUILD_TYPE=Release ${{matrix.config.extraCMakeConfig}}
+        cmake --build .
+        
+    - name: AppImage (Linux)
+      if: runner.os == 'Linux' && !contains(github.ref, 'tags/v') && !contains(github.ref, 'refs/heads/main') && !contains(github.ref, 'refs/heads/release-')
+      run: |
+        wget -qc "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+        wget -qc "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
+        chmod a+x linuxdeploy*.AppImage
         export VERSION=${{ needs.store-sha8.outputs.sha8 }}
-        ./linuxdeployqt-continuous-x86_64.AppImage appdir/usr/share/applications/*.desktop -appimage -verbose=2
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:libs
+        ${{matrix.config.linuxDeployQtPath}}
+        ./linuxdeploy-x86_64.AppImage --appdir=appdir  --output appimage \
+          -e ashirt \
+          -d linux/ashirt.desktop \
+          -i linux/icons/128x128/apps/ashirt.png \
+          --plugin=qt
         mkdir -p dist
         # file should be named ashirt-${{ needs.store-sha8.outputs.sha8 }}-x86_64.AppImage
         mv ashirt*.AppImage dist/
 
-    - name: Build PR (mac)
+    - name: DeployPR (mac)
       if: |
-        matrix.os == 'macos-latest' &&
+        matrix.config.os == 'macos-latest' &&
         contains(github.ref, 'tags/v') != true &&
         contains(github.ref, 'refs/heads/main') != true &&
         contains(github.ref, 'refs/heads/release') != true
       run: |
-        brew install qt@5
-        export PATH="/usr/local/opt/qt@5/bin:$PATH"
-        brew link -f qt@5
-        qmake -config release
-        make
         macdeployqt ashirt.app -dmg
         mkdir -p dist
         cp ashirt.dmg dist/ashirt.dmg
@@ -97,23 +135,18 @@ jobs:
 
     - name: Import Code-Signing Certificates
       if: |
-        matrix.os == 'macos-latest' &&
+        matrix.config.os == 'macos-latest' &&
         (contains(github.ref, 'tags/v') || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release'))
       uses: Apple-Actions/import-codesign-certs@v1.0.4
       with:
         p12-file-base64: ${{ secrets.MACOS_CERT }}
         p12-password: ${{ secrets.MACOS_PASS }}
 
-    - name: Build and Sign Release (mac)
+    - name: Sign Release (mac)
       if: |
-        matrix.os == 'macos-latest' &&
+        matrix.config.os == 'macos-latest' &&
         (contains(github.ref, 'tags/v') || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release'))
       run: |
-        brew install qt@5
-        export PATH="/usr/local/opt/qt@5/bin:$PATH"
-        brew link -f qt@5
-        qmake -config release
-        make
         macdeployqt ashirt.app -dmg -always-overwrite -sign-for-notarization="John Kennedy"
         mkdir -p dist
         cp ashirt.dmg dist/ashirt.dmg
@@ -122,7 +155,7 @@ jobs:
 
     - name: Install gon via HomeBrew and Notarize (mac)
       if: |
-        matrix.os == 'macos-latest' &&
+        matrix.config.os == 'macos-latest' &&
         (contains(github.ref, 'tags/v') || github.ref == 'refs/heads/main' || contains(github.ref, 'refs/heads/release'))
       env: 
         GON_CONF: ${{ secrets.GON_CONF }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,194 @@
+cmake_minimum_required(VERSION 3.18)
+
+project(ashirt VERSION 1.2.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+if(EXISTS ${CMAKE_SOURCE_DIR}/.git)
+    find_package(Git)
+    if(GIT_FOUND)
+     EXECUTE_PROCESS(
+      COMMAND ${GIT_EXECUTABLE} describe --long --match v*
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE GITREV
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+     string(REGEX MATCH [0-9]+ MAJOR ${GITREV})
+     string(REGEX MATCH \\.[0-9]+ MINOR ${GITREV})
+     string(REPLACE "." "" MINOR ${MINOR})
+     string(REGEX MATCH [0-9]+\- PATCH ${GITREV})
+     string(REPLACE "-" "" PATCH ${PATCH})
+     string(REGEX MATCH \-[0-9]+\- TWEAK ${GITREV})
+     string(REPLACE "-" "" TWEAK ${TWEAK})
+     set(CMAKE_PROJECT_VERSION_MAJOR ${MAJOR})
+     set(CMAKE_PROJECT_VERSION_MINOR ${MINOR})
+     set(CMAKE_PROJECT_VERSION_PATCH ${PATCH})
+     set(CMAKE_PROJECT_VERSION_TWEAK ${TWEAK})
+     set(CMAKE_PROJECT_VERSION "${MAJOR}.${MINOR}.${PATCH}.${TWEAK}")
+     add_definitions(-DVERSION_TAG="v${MAJOR}.${MINOR}.${PATCH}")
+     EXECUTE_PROCESS(
+      COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE GITHASH
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+     add_definitions(-DCOMMIT_HASH="${GITHASH}")
+    EXECUTE_PROCESS(
+      COMMAND ${GIT_EXECUTABLE} remote get-url origin
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+      OUTPUT_VARIABLE GITORIGIN
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    add_definitions(-DSOURCE_CONTROL_REPO="${GITORIGIN}")
+    endif()
+else()
+    add_definitions(-DCOMMIT_HASH="")
+    add_definitions(-DVERSION_TAG="")
+    add_definitions(-DSOURCE_CONTROL_REPO="")
+    add_definitions(-DVERSION_TAG_PLAIN "v0.0.0-development")
+    add_definitions(-DCOMMIT_HASH_PLAIN "Unknown")
+endif()
+     message(STATUS "VERSION: ${CMAKE_PROJECT_VERSION}")
+
+if(NOT QT_DEFAULT_MAJOR_VERSION)
+    set(QT_DEFAULT_MAJOR_VERSION 5 CACHE STRING "" FORCE)
+endif()
+
+find_package(Qt${QT_DEFAULT_MAJOR_VERSION} REQUIRED COMPONENTS
+    Widgets
+    Gui
+    Network
+    Sql
+    Core
+)
+
+##Possible future private static?
+add_library(UGlobalHotkey
+        tools/UGlobalHotkey/hotkeymap.h
+        tools/UGlobalHotkey/uglobal.h
+        tools/UGlobalHotkey/uglobalhotkeys.cpp tools/UGlobalHotkey/uglobalhotkeys.h
+        tools/UGlobalHotkey/ukeysequence.cpp tools/UGlobalHotkey/ukeysequence.h
+)
+target_include_directories(UGlobalHotkey PRIVATE ${Qt${QT_DEFAULT_MAJOR_VERSION}Gui_PRIVATE_INCLUDE_DIRS}/qpa)
+target_link_libraries(UGlobalHotkey
+    PUBLIC
+        Qt::Core Qt::Gui Qt::Widgets
+    PRIVATE
+        Qt::GuiPrivate
+)
+if(APPLE)
+    find_library(CARBON_LIBRARY Carbon)
+    target_link_libraries(UGlobalHotkey PRIVATE ${CARBON_LIBRARY})
+elseif(UNIX AND NOT APPLE)
+    target_link_libraries(UGlobalHotkey PRIVATE xcb xcb-keysyms)
+elseif(WIN32)
+    target_link_libraries(UGlobalHotkey PRIVATE user32)
+endif()
+
+include_directories(${CMAKE_SOURCE_DIR}/src)
+
+set(ASHIRT_SOURCES
+    src/appconfig.h
+    src/appsettings.h
+    src/components/aspectratio_pixmap_label/aspectratiopixmaplabel.cpp src/components/aspectratio_pixmap_label/aspectratiopixmaplabel.h
+    src/components/aspectratio_pixmap_label/imageview.cpp src/components/aspectratio_pixmap_label/imageview.h
+    src/components/code_editor/codeblockview.cpp src/components/code_editor/codeblockview.h
+    src/components/code_editor/codeeditor.cpp src/components/code_editor/codeeditor.h
+    src/components/custom_keyseq_edit/singlestrokekeysequenceedit.cpp src/components/custom_keyseq_edit/singlestrokekeysequenceedit.h
+    src/components/error_view/errorview.cpp src/components/error_view/errorview.h
+    src/components/evidence_editor/deleteevidenceresponse.h
+    src/components/evidence_editor/evidenceeditor.cpp src/components/evidence_editor/evidenceeditor.h
+    src/components/evidence_editor/saveevidenceresponse.h
+    src/components/evidencepreview.cpp src/components/evidencepreview.h
+    src/components/flow_layout/flowlayout.cpp src/components/flow_layout/flowlayout.h
+    src/components/loading/qprogressindicator.cpp src/components/loading/qprogressindicator.h
+    src/components/loading_button/loadingbutton.cpp src/components/loading_button/loadingbutton.h
+    src/components/tagging/tag_cache/tagcache.cpp src/components/tagging/tag_cache/tagcache.h
+    src/components/tagging/tag_cache/tagcacheitem.cpp src/components/tagging/tag_cache/tagcacheitem.h
+    src/components/tagging/tageditor.cpp src/components/tagging/tageditor.h
+    src/components/tagging/tagginglineediteventfilter.h
+    src/components/tagging/tagview.cpp src/components/tagging/tagview.h
+    src/components/tagging/tagwidget.cpp src/components/tagging/tagwidget.h
+    src/db/databaseconnection.cpp src/db/databaseconnection.h
+    src/db/query_result.h
+    src/dtos/checkConnection.h
+    src/dtos/github_release.h
+    src/dtos/operation.h
+    src/dtos/tag.h
+    src/exceptions/databaseerr.h
+    src/exceptions/fileerror.h
+    src/forms/add_operation/createoperation.cpp src/forms/add_operation/createoperation.h
+    src/forms/credits/credits.cpp src/forms/credits/credits.h
+    src/forms/evidence/evidencemanager.cpp src/forms/evidence/evidencemanager.h
+    src/forms/evidence_filter/evidencefilter.cpp src/forms/evidence_filter/evidencefilter.h
+    src/forms/evidence_filter/evidencefilterform.cpp src/forms/evidence_filter/evidencefilterform.h
+    src/forms/getinfo/getinfo.cpp src/forms/getinfo/getinfo.h
+    src/forms/porting/porting_dialog.cpp src/forms/porting/porting_dialog.h
+    src/forms/settings/settings.cpp src/forms/settings/settings.h
+    src/helpers/clipboard/clipboardhelper.cpp src/helpers/clipboard/clipboardhelper.h
+    src/helpers/constants.h
+    src/helpers/file_helpers.h
+    src/helpers/http_status.h
+    src/helpers/jsonhelpers.h
+    src/helpers/multipartparser.cpp src/helpers/multipartparser.h
+    src/helpers/netman.h
+    src/helpers/request_builder.h
+    src/helpers/screenshot.cpp src/helpers/screenshot.h
+    src/helpers/stopreply.cpp src/helpers/stopreply.h
+    src/helpers/system_helpers.h
+    src/helpers/ui_helpers.h
+    src/hotkeymanager.cpp src/hotkeymanager.h
+    src/main.cpp
+    src/models/codeblock.cpp src/models/codeblock.h
+    src/models/evidence.h
+    src/models/tag.h
+    src/porting/evidence_manifest.h
+    src/porting/system_manifest.cpp src/porting/system_manifest.h
+    src/porting/system_porting_options.h
+    src/traymanager.cpp src/traymanager.h
+    res_icons.qrc
+    res_migrations.qrc
+)
+
+if(APPLE)
+    set(ASHIRT_PLATFORM_EX_SRC ${CMAKE_SOURCE_DIR}/icons/ashirt.icns)
+    set_source_files_properties(${ASHIRT_PLATFORM_EX_SRC} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+endif()
+
+#MACOSX_BUNDLE Make it a bundle on Mac OS
+#WIN32 Its a "GUI" app on win32
+add_executable(ashirt MACOSX_BUNDLE WIN32 ${ASHIRT_SOURCES} ${ASHIRT_PLATFORM_EX_SRC})
+set_target_properties(ashirt PROPERTIES
+    MACOSX_BUNDLE_GUI_IDENTIFIER "com.theparanoids.ashirt"
+    MACOSX_BUNDLE_BUNDLE_NAME "ashirt"
+    MACOSX_BUNDLE_ICON_FILE icons/ashirt.icns
+    MACOSX_BUNDLE_BUNDLE_VERSION ${CMAKE_PROJECT_VERSION}
+    MACOSX_BUNDLE_SHORT_VERSION_STRING "${CMAKE_PROJECT_VERSION}"
+    )
+
+target_link_libraries ( ashirt
+    PRIVATE
+        Qt::Widgets
+        Qt::Sql
+        Qt::Gui
+        Qt::Network
+        UGlobalHotkey
+)
+if(UNIX AND NOT APPLE)
+    target_link_libraries ( ashirt PRIVATE pthread)
+endif()
+
+install(TARGETS ashirt
+          BUNDLE DESTINATION .
+          RUNTIME DESTINATION bin
+)
+
+if(UNIX AND NOT APPLE)
+    install(FILES ${CMAKE_SOURCE_DIR}/linux/icons/* DESTINATION share/icons/hicolor)
+    install(FILES ${CMAKE_SOURCE_DIR}/linux/ashirt.desktop DESTINATION share/applictions)
+endif()


### PR DESCRIPTION
Replaces #109, #113
Fixes: #102, #93, #72, #103
### CMake
 - Create basic CMakeLists.txt
 - Provide basic install info in CMakeLists (needed for appimage)
 ### Improve CI
 - Build / deploy w/ Qt5(5.15.2) and Qt6 (6.2.3)
 - Cache and install Qt using the Qt Action
 - Build with Cmake