### PR TITLE
Deprecation Cleanup

### DIFF
--- a/src/components/tagging/tagwidget.cpp
+++ b/src/components/tagging/tagwidget.cpp
@@ -24,9 +24,13 @@ void TagWidget::setReadOnly(bool readonly) {
 }
 
 void TagWidget::mouseReleaseEvent(QMouseEvent* evt) {
-  const int x = evt->x();
-  const int y = evt->y();
-
+#if(QT_VERSION_MAJOR > 5)
+  const int x = evt->position().x();
+  const int y = evt->position().y();
+#else
+    const int x = evt->x();
+    const int y = evt->y();
+#endif
   if (removeArea.contains(x, y)) {
     emit removePressed();
   }

--- a/src/db/databaseconnection.cpp
+++ b/src/db/databaseconnection.cpp
@@ -439,7 +439,7 @@ QSqlQuery DatabaseConnection::executeQuery(const QSqlDatabase& db, const QString
   if (!result.success) {
     throw result.err;
   }
-  return result.query;
+  return std::move(result.query);
 }
 
 QueryResult DatabaseConnection::executeQueryNoThrow(const QSqlDatabase& db, const QString &stmt,
@@ -448,14 +448,14 @@ QueryResult DatabaseConnection::executeQueryNoThrow(const QSqlDatabase& db, cons
 
   bool prepared = query.prepare(stmt);
   if (!prepared) {
-    return QueryResult(query);
+    return QueryResult(std::move(query));
   }
   for (const auto &arg : args) {
     query.addBindValue(arg);
   }
 
   query.exec();
-  return QueryResult(query);
+  return QueryResult(std::move(query));
 }
 
 // doInsert is a version of executeQuery that returns the last inserted id, rather than the

--- a/src/db/query_result.h
+++ b/src/db/query_result.h
@@ -15,8 +15,8 @@ class QueryResult {
  public:
   QueryResult(){}
   QueryResult(QSqlQuery query) {
-    this->query = query;
     this->err = query.lastError();
+    this->query = std::move(query);
     this->success = err.type() == QSqlError::NoError;
   }
 

--- a/src/forms/porting/porting_dialog.cpp
+++ b/src/forms/porting/porting_dialog.cpp
@@ -172,7 +172,7 @@ void PortingDialog::onSubmitPressed() {
   connect(executedManifest, &porting::SystemManifest::onStatusUpdate, portStatusLabel, &QLabel::setText);
   connect(this, &PortingDialog::onWorkComplete, this, &PortingDialog::onPortComplete);
 
-  QtConcurrent::run(portAction);
+  std::ignore = QtConcurrent::run(portAction);
 }
 
 void PortingDialog::onPortComplete(bool success) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,7 +26,9 @@ int main(int argc, char* argv[]) {
   Q_INIT_RESOURCE(res_icons);
   Q_INIT_RESOURCE(res_migrations);
 
+#if (QT_VERSION_MAJOR < 6)
   QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
   QCoreApplication::setApplicationName("ashirt");
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
 - Fix Qt deprecated calls; Use correct call based on Qt Version 
 - Clean warning for unused return
 - **QSqlQuery::operator=  has been replaced by std::move(QSqlQuery)**
      -  Double check database querys are still working as expected.
