### PR TITLE
try to sign

### DIFF
--- a/deploy/generate_ds_store.applescript
+++ b/deploy/generate_ds_store.applescript
@@ -42,7 +42,10 @@ on run argv
         set position of item "ashirt.app" to { 0, 225 }
         set position of item "README.MD" to { 250, 0 }
         set position of item "Applications" to { 500, 225 }
-        do shell script "codesign -v -f --timestamp --options runtime --sign \"$(cat deploy/NOTARIZE_AS)\" /Volumes/" & image_name & "/ashirt.app/Contents/MacOS/ashirt"
+        try
+            do shell script "codesign -v -f --timestamp --options runtime --sign \"$(cat deploy/NOTARIZE_AS)\" /Volumes/" & image_name & "/ashirt.app/Contents/MacOS/ashirt"
+            do shell script "codesign -v -f --timestamp --options runtime --sign \"$(cat deploy/NOTARIZE_AS)\" /Volumes/" & image_name & "/ashirt.app/Contents/Frameworks/libbrotlicommon.1.dylib"
+        end try
       end tell
       delay 5
     close

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,11 +67,14 @@ if(APPLE)
         )
     else()
         message(STATUS "Sign Bundle As: ${NOTARIZE_AS}")
+        set(HOMEBREW_CELLAR "/usr/local/Cellar")
+        if(EXISTS /opt/homebrew/Cellar)
+            set(HOMEBREW_CELLAR "/opt/homebrew/Cellar")
+        endif()
         add_custom_command(
             TARGET ashirt POST_BUILD
-            COMMAND mkdir ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks
-            COMMAND cp /usr/local/Cellar/brotli/1.0.9/lib/libbrotlicommon.1.0.9.dylib ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks/libbrotlicommon.1.dylib
-            COMMAND codesign -v --timestamp --sign ${NOTARIZE_AS} ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks/libbrotlicommon.1.dylib
+            COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks
+            COMMAND install ${HOMEBREW_CELLAR}/brotli/1.0.9/lib/libbrotlicommon.1.0.9.dylib ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks/libbrotlicommon.1.dylib
             COMMAND ${PLATFORMDEPLOYQT} ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app -sign-for-notarization=${NOTARIZE_AS}
         )
     endif()


### PR DESCRIPTION
- Allow the macOS package to still build if the signing key is missing
- Check for the paths homebrew cellar can be and use M1 or Intel path.
- Move signing of libbrotlicommon.1.dylib to the applescript to allow it a fail on missing signature