### PR TITLE
Fix Signing for all

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,8 @@ jobs:
             name: "Mac-Qt6"
             , os: macos-latest
             , QT_VERSION: 6.3.0, QT_INST_DIR: /Users/runner
-            , extraCMakeConfig: "-DCMAKE_OSX_ARCHITECTURES=\"arm64;x86_64\" -DNOTARIZE_AS=\"John Kennedy\""
+            , extraCMakeConfig: "-DCMAKE_OSX_ARCHITECTURES=\"arm64;x86_64\""
+            , cmakeSigning: "-DNOTARIZE_AS=\"John Kennedy\""
             , buildTarget: "--target package"
           }
         - {
@@ -134,7 +135,11 @@ jobs:
     - name: Build
       shell: bash
       run: |
-        cmake -DCMAKE_BUILD_TYPE=Release -DCPACK_PACKAGE_VERSION=${{env.githash}} ${{matrix.config.extraCMakeConfig}}
+        if [[ "${{ env.signRelease }}" == "true" ]]; then
+            cmake -DCMAKE_BUILD_TYPE=Release -DCPACK_PACKAGE_VERSION=${{env.githash}} ${{matrix.config.extraCMakeConfig}} ${{matrix.config.cmakeSigning}}
+        else
+            cmake -DCMAKE_BUILD_TYPE=Release -DCPACK_PACKAGE_VERSION=${{env.githash}} ${{matrix.config.extraCMakeConfig}}
+        fi
         cmake --build . ${{ matrix.config.buildTarget }}
         mkdir -p dist
         if [ "$RUNNER_OS" == "Linux" ]; then

--- a/deploy/generate_ds_store.applescript
+++ b/deploy/generate_ds_store.applescript
@@ -44,7 +44,6 @@ on run argv
         set position of item "Applications" to { 500, 225 }
         try
             do shell script "codesign -v -f --timestamp --options runtime --sign \"$(cat deploy/NOTARIZE_AS)\" /Volumes/" & image_name & "/ashirt.app/Contents/MacOS/ashirt"
-            do shell script "codesign -v -f --timestamp --options runtime --sign \"$(cat deploy/NOTARIZE_AS)\" /Volumes/" & image_name & "/ashirt.app/Contents/Frameworks/libbrotlicommon.1.dylib"
         end try
       end tell
       delay 5

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ if(APPLE)
             TARGET ashirt POST_BUILD
             COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks
             COMMAND install ${HOMEBREW_CELLAR}/brotli/1.0.9/lib/libbrotlicommon.1.0.9.dylib ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks/libbrotlicommon.1.dylib
+            COMMAND codesign -v --timestamp --sign ${NOTARIZE_AS} ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks/libbrotlicommon.1.dylib
             COMMAND ${PLATFORMDEPLOYQT} ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app -sign-for-notarization=${NOTARIZE_AS}
         )
     endif()


### PR DESCRIPTION
 - Move code sign of the extra lib back to cmake
 - Only set `NOTARIZE_AS` for CI jobs that can sign.