### PR TITLE
Common dialog base

### DIFF
--- a/src/forms/CMakeLists.txt
+++ b/src/forms/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 add_library (FORMS STATIC
     add_operation/createoperation.cpp add_operation/createoperation.h
+    ashirtdialog/ashirtdialog.cpp ashirtdialog/ashirtdialog.h
     credits/credits.cpp credits/credits.h
     evidence/evidencemanager.cpp evidence/evidencemanager.h
     evidence_filter/evidencefilter.cpp evidence_filter/evidencefilter.h

--- a/src/forms/add_operation/createoperation.cpp
+++ b/src/forms/add_operation/createoperation.cpp
@@ -7,13 +7,14 @@
 #include "dtos/ashirt_error.h"
 #include "appsettings.h"
 
-CreateOperation::CreateOperation(QWidget* parent) : QDialog(parent) {
+CreateOperation::CreateOperation(QWidget* parent)
+  : AShirtDialog(parent, AShirtDialog::commonWindowFlags)
+{
   buildUi();
   wireUi();
 }
 
 CreateOperation::~CreateOperation() {
-  delete closeWindowAction;
   delete submitButton;
   delete _operationLabel;
   delete responseLabel;
@@ -55,18 +56,9 @@ void CreateOperation::buildUi() {
   // row 2
   gridLayout->addWidget(submitButton, 2, 2);
 
-  closeWindowAction = new QAction(this);
-  closeWindowAction->setShortcut(QKeySequence::Close);
-  this->addAction(closeWindowAction);
-
   this->setLayout(gridLayout);
   this->resize(400, 1);
   this->setWindowTitle(tr("Create Operation"));
-
-  Qt::WindowFlags flags = this->windowFlags();
-  flags |= Qt::CustomizeWindowHint | Qt::WindowStaysOnTopHint | Qt::WindowMinMaxButtonsHint |
-           Qt::WindowCloseButtonHint;
-  this->setWindowFlags(flags);
 }
 
 void CreateOperation::wireUi() {

--- a/src/forms/add_operation/createoperation.h
+++ b/src/forms/add_operation/createoperation.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QAction>
-#include <QDialog>
+#include "ashirtdialog/ashirtdialog.h"
+
 #include <QGridLayout>
 #include <QLabel>
 #include <QLineEdit>
@@ -9,7 +9,7 @@
 
 #include "components/loading_button/loadingbutton.h"
 
-class CreateOperation : public QDialog {
+class CreateOperation : public AShirtDialog {
   Q_OBJECT
 
  public:
@@ -35,7 +35,6 @@ class CreateOperation : public QDialog {
 
   // ui elements
   QGridLayout* gridLayout = nullptr;
-  QAction* closeWindowAction = nullptr;
   LoadingButton* submitButton = nullptr;
   QLabel* _operationLabel = nullptr;
   QLabel* responseLabel = nullptr;

--- a/src/forms/ashirtdialog/ashirtdialog.cpp
+++ b/src/forms/ashirtdialog/ashirtdialog.cpp
@@ -1,0 +1,14 @@
+#include "ashirtdialog.h"
+#include <QKeySequence>
+
+AShirtDialog::AShirtDialog(QWidget *parent, Qt::WindowFlags windowFlags) : QDialog(parent, windowFlags)
+{
+  addAction(QString(), QKeySequence::Close, this, &AShirtDialog::close);
+}
+
+void AShirtDialog::show()
+{
+    QDialog::show(); // display the window
+    raise(); // bring to the top (mac)
+    activateWindow(); // alternate bring to the top (windows)
+}

--- a/src/forms/ashirtdialog/ashirtdialog.h
+++ b/src/forms/ashirtdialog/ashirtdialog.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QDialog>
+
+/**
+ * @brief The AShirtDialog class represents a base class used for all dialogs.
+ */
+class AShirtDialog : public QDialog {
+  Q_OBJECT
+
+ public:
+  ///Create a AShirtDialog.
+  AShirtDialog(QWidget* parent = nullptr, Qt::WindowFlags windowFlags = Qt::WindowFlags());
+
+  /// show Overridden Show forces window to top
+  void show();
+
+  ///Commonly used windowFlags
+  inline static const Qt::WindowFlags commonWindowFlags =
+              Qt::WindowFlags()
+              | Qt::CustomizeWindowHint
+              | Qt::WindowStaysOnTopHint
+              | Qt::WindowMinMaxButtonsHint
+              | Qt::WindowCloseButtonHint;
+};

--- a/src/forms/credits/credits.cpp
+++ b/src/forms/credits/credits.cpp
@@ -105,7 +105,9 @@ static std::string normalBodyMarkdown() {
   // clang-format on
 }
 
-Credits::Credits(QWidget* parent) : QDialog(parent) {
+Credits::Credits(QWidget* parent)
+  : AShirtDialog(parent, AShirtDialog::commonWindowFlags)
+{
   buildUi();
   wireUi();
 }
@@ -158,29 +160,17 @@ void Credits::buildUi() {
   // row 2
   gridLayout->addWidget(buttonBox, 2, 0);
 
-  closeWindowAction = new QAction(this);
-  closeWindowAction->setShortcut(QKeySequence::Close);
-  this->addAction(closeWindowAction);
-
   this->setLayout(gridLayout);
   this->resize(640, 500);
   this->setWindowTitle("About");
-
-  // Make the dialog pop up above any other windows but retain title bar and buttons
-  Qt::WindowFlags flags = this->windowFlags();
-  flags |= Qt::CustomizeWindowHint | Qt::WindowStaysOnTopHint | Qt::WindowMinMaxButtonsHint |
-           Qt::WindowCloseButtonHint;
-  this->setWindowFlags(flags);
 }
 
 void Credits::wireUi() {
-  connect(closeWindowAction, &QAction::triggered, this, &QDialog::close);
   connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::close);
   connect(&NetMan::getInstance(), &NetMan::releasesChecked, this, &Credits::onReleasesUpdate);
 }
 
 Credits::~Credits() {
-  delete closeWindowAction;
   delete updateLabel;
   delete creditsArea;
   delete buttonBox;

--- a/src/forms/credits/credits.h
+++ b/src/forms/credits/credits.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <QAction>
-#include <QDialog>
+#include "ashirtdialog/ashirtdialog.h"
+
 #include <QLabel>
 #include <QTextBrowser>
 #include <QDialogButtonBox>
@@ -12,7 +12,7 @@
 
 #include "dtos/github_release.h"
 
-class Credits : public QDialog {
+class Credits : public AShirtDialog {
   Q_OBJECT
 
  public:
@@ -32,8 +32,6 @@ class Credits : public QDialog {
   void updateRelease();
 
  private:
-  QAction* closeWindowAction = nullptr;
-
   // UI Components
   QGridLayout* gridLayout = nullptr;
   QTextBrowser* creditsArea = nullptr;

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -48,7 +48,9 @@ static QStringList columnNames() {
   return names;
 }
 
-EvidenceManager::EvidenceManager(DatabaseConnection* db, QWidget* parent) : QDialog(parent) {
+EvidenceManager::EvidenceManager(DatabaseConnection* db, QWidget* parent)
+  : AShirtDialog(parent)
+{
   this->db = db;
   buildUi();
   wireUi();
@@ -59,7 +61,6 @@ EvidenceManager::~EvidenceManager() {
   delete deleteEvidenceAction;
   delete copyPathToClipboardAction;
   delete deleteTableContentsAction;
-  delete closeWindowAction;
   delete evidenceTableContextMenu;
   delete filterForm;
   delete evidenceEditor;
@@ -174,10 +175,6 @@ void EvidenceManager::buildUi() {
   gridLayout->addWidget(cancelEditButton, 3, 2);
   gridLayout->addWidget(editButton, 3, 3);
 
-  closeWindowAction = new QAction(this);
-  closeWindowAction->setShortcut(QKeySequence::Close);
-  this->addAction(closeWindowAction);
-
   this->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
   this->resize(800, 600);
   this->setWindowTitle(tr("Evidence Manager"));
@@ -197,7 +194,6 @@ void EvidenceManager::wireUi() {
 
   connect(submitEvidenceAction, actionTriggered, this, &EvidenceManager::submitEvidenceTriggered);
   connect(deleteEvidenceAction, actionTriggered, this, &EvidenceManager::deleteEvidenceTriggered);
-  connect(closeWindowAction, actionTriggered, this, &EvidenceManager::close);
   connect(copyPathToClipboardAction, actionTriggered, this, &EvidenceManager::copyPathTriggered);
   connect(deleteTableContentsAction, actionTriggered, this, &EvidenceManager::deleteAllTriggered);
 

--- a/src/forms/evidence/evidencemanager.h
+++ b/src/forms/evidence/evidencemanager.h
@@ -3,8 +3,9 @@
 
 #pragma once
 
+#include "ashirtdialog/ashirtdialog.h"
+
 #include <QAction>
-#include <QDialog>
 #include <QLineEdit>
 #include <QMenu>
 #include <QNetworkReply>
@@ -34,7 +35,7 @@ struct EvidenceRow {
  * @brief The EvidenceManager class represents the Evidence Manager window that is shown
  * when selecting "View Accumulated Evidence."
  */
-class EvidenceManager : public QDialog {
+class EvidenceManager : public AShirtDialog {
   Q_OBJECT
 
  public:
@@ -126,7 +127,6 @@ class EvidenceManager : public QDialog {
 
   QAction* submitEvidenceAction = nullptr;
   QAction* deleteEvidenceAction = nullptr;
-  QAction* closeWindowAction = nullptr;
   QAction* copyPathToClipboardAction = nullptr;
   QAction* deleteTableContentsAction = nullptr;
 

--- a/src/forms/evidence_filter/evidencefilterform.cpp
+++ b/src/forms/evidence_filter/evidencefilterform.cpp
@@ -24,14 +24,12 @@ static void initializeDateEdit(QDateEdit *dateEdit) {
 }
 
 EvidenceFilterForm::EvidenceFilterForm(QWidget *parent)
-    : QDialog(parent) {
+    : AShirtDialog(parent) {
   buildUi();
   wireUi();
 }
 
 EvidenceFilterForm::~EvidenceFilterForm() {
-  delete closeWindowAction;
-
   delete _operationLabel;
   delete _contentTypeLabel;
   delete _hadErrorLabel;
@@ -140,10 +138,6 @@ void EvidenceFilterForm::buildUi() {
   // row 6
   gridLayout->addWidget(buttonBox, 6, 0, 1, gridLayout->columnCount());
 
-  closeWindowAction = new QAction(this);
-  closeWindowAction->setShortcut(QKeySequence::Close);
-  this->addAction(closeWindowAction);
-
   this->setLayout(gridLayout);
   this->setWindowTitle(tr("Evidence Filters"));
   this->resize(320, 245);
@@ -163,8 +157,6 @@ void EvidenceFilterForm::wireUi() {
           [this](bool checked) { fromDateEdit->setEnabled(checked); });
   connect(includeEndDateCheckBox, &QCheckBox::stateChanged, this,
           [this](bool checked) { toDateEdit->setEnabled(checked); });
-
-  connect(closeWindowAction, &QAction::triggered, this, &EvidenceFilterForm::writeAndClose);
 }
 
 void EvidenceFilterForm::writeAndClose() {

--- a/src/forms/evidence_filter/evidencefilterform.h
+++ b/src/forms/evidence_filter/evidencefilterform.h
@@ -3,9 +3,8 @@
 
 #pragma once
 
-#include <QComboBox>
-#include <QDialog>
-#include <QAction>
+#include "ashirtdialog/ashirtdialog.h"
+
 #include <QGridLayout>
 #include <QLabel>
 #include <QComboBox>
@@ -16,7 +15,7 @@
 #include "db/databaseconnection.h"
 #include "dtos/operation.h"
 
-class EvidenceFilterForm : public QDialog {
+class EvidenceFilterForm : public AShirtDialog {
   Q_OBJECT
 
  public:
@@ -49,8 +48,6 @@ class EvidenceFilterForm : public QDialog {
   EvidenceFilters encodeForm();
 
  private:
-  QAction* closeWindowAction = nullptr;
-
   // UI Components
   QGridLayout* gridLayout = nullptr;
   QLabel* _operationLabel = nullptr;

--- a/src/forms/getinfo/getinfo.cpp
+++ b/src/forms/getinfo/getinfo.cpp
@@ -13,10 +13,10 @@
 #include "helpers/ui_helpers.h"
 
 GetInfo::GetInfo(DatabaseConnection* db, qint64 evidenceID, QWidget* parent)
-    : QDialog(parent), db(db), evidenceID(evidenceID) {
-  this->db = db;
-  this->evidenceID = evidenceID;
-
+    : AShirtDialog(parent, AShirtDialog::commonWindowFlags)
+    , db(db)
+    , evidenceID(evidenceID)
+{
   buildUi();
   wireUi();
 }
@@ -25,7 +25,6 @@ GetInfo::~GetInfo() {
   delete evidenceEditor;
   delete submitButton;
   delete deleteButton;
-  delete closeWindowAction;
 
   delete gridLayout;
   stopReply(&uploadAssetReply);
@@ -62,27 +61,17 @@ void GetInfo::buildUi() {
   gridLayout->addWidget(deleteButton, 1, 0);
   gridLayout->addWidget(submitButton, 1, 2);
 
-  closeWindowAction = new QAction(this);
-  closeWindowAction->setShortcut(QKeySequence::Close);
-  this->addAction(closeWindowAction);
-
   this->setLayout(gridLayout);
   this->setAttribute(Qt::WA_DeleteOnClose);
   this->resize(720, 480);
   this->setWindowTitle(tr("Add Evidence Details"));
 
-  // Make the dialog pop up above any other windows but retain title bar and buttons
-  Qt::WindowFlags flags = this->windowFlags();
-  flags |= Qt::CustomizeWindowHint | Qt::WindowStaysOnTopHint | Qt::WindowMinMaxButtonsHint |
-           Qt::WindowCloseButtonHint;
-  this->setWindowFlags(flags);
   setFocus(); // ensure focus is not on the submit button
 }
 
 void GetInfo::wireUi() {
   connect(submitButton, &QPushButton::clicked, this, &GetInfo::submitButtonClicked);
   connect(deleteButton, &QPushButton::clicked, this, &GetInfo::deleteButtonClicked);
-  connect(closeWindowAction, &QAction::triggered, this, &GetInfo::deleteButtonClicked);
 }
 
 void GetInfo::showEvent(QShowEvent* evt) {

--- a/src/forms/getinfo/getinfo.h
+++ b/src/forms/getinfo/getinfo.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include "ashirtdialog/ashirtdialog.h"
+
 #include <QGridLayout>
-#include <QAction>
-#include <QDialog>
 #include <QNetworkReply>
 
 #include "components/evidence_editor/evidenceeditor.h"
@@ -18,7 +18,7 @@ namespace Ui {
 class GetInfo;
 }
 
-class GetInfo : public QDialog {
+class GetInfo : public AShirtDialog {
   Q_OBJECT
 
  public:
@@ -48,9 +48,6 @@ class GetInfo : public QDialog {
   qint64 evidenceID;
 
   QNetworkReply *uploadAssetReply = nullptr;
-
-  // Actions
-  QAction* closeWindowAction = nullptr;
 
   // Ui Components
   QGridLayout* gridLayout;

--- a/src/forms/porting/porting_dialog.cpp
+++ b/src/forms/porting/porting_dialog.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 
 PortingDialog::PortingDialog(PortType dialogType, DatabaseConnection* db, QWidget *parent)
-  : QDialog(parent) {
+  : AShirtDialog(parent) {
   this->dialogType = dialogType;
   this->db = db;
 
@@ -15,7 +15,6 @@ PortingDialog::PortingDialog(PortType dialogType, DatabaseConnection* db, QWidge
 }
 
 PortingDialog::~PortingDialog() {
-  delete closeWindowAction;
 
   delete _selectFileLabel;
   delete portConfigCheckBox;
@@ -91,10 +90,6 @@ void PortingDialog::buildUi() {
 
   // row 5
   gridLayout->addWidget(submitButton, 5, 2);
-
-  closeWindowAction = new QAction(this);
-  closeWindowAction->setShortcut(QKeySequence::Close);
-  this->addAction(closeWindowAction);
 
   this->setLayout(gridLayout);
   this->resize(500, 1);

--- a/src/forms/porting/porting_dialog.h
+++ b/src/forms/porting/porting_dialog.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QAction>
+#include "ashirtdialog/ashirtdialog.h"
+
 #include <QCheckBox>
-#include <QDialog>
 #include <QGridLayout>
 #include <QLabel>
 #include <QLineEdit>
@@ -19,7 +19,7 @@
  * while Export will render an export window.
  * @see PortType
  */
-class PortingDialog : public QDialog {
+class PortingDialog : public AShirtDialog {
   Q_OBJECT
 
  public:
@@ -93,8 +93,6 @@ class PortingDialog : public QDialog {
   /// executedManifest contains a pointer to the system manifest used to import/export data
   /// Saved so that it can be cleaned up post-execution
   porting::SystemManifest* executedManifest = nullptr;
-
-  QAction* closeWindowAction = nullptr;
 
   // UI Components
   QGridLayout* gridLayout = nullptr;

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -18,7 +18,9 @@
 #include "hotkeymanager.h"
 #include "components/custom_keyseq_edit/singlestrokekeysequenceedit.h"
 
-Settings::Settings(HotkeyManager *hotkeyManager, QWidget *parent) : QDialog(parent) {
+Settings::Settings(HotkeyManager *hotkeyManager, QWidget *parent)
+  : AShirtDialog(parent, AShirtDialog::commonWindowFlags)
+{
   this->hotkeyManager = hotkeyManager;
   buildUi();
   wireUi();
@@ -53,7 +55,6 @@ Settings::~Settings() {
 
   delete couldNotSaveSettingsMsg;
   stopReply(&currentTestReply);
-  delete closeWindowAction;
 }
 
 void Settings::buildUi() {
@@ -157,20 +158,10 @@ void Settings::buildUi() {
   // row 9
   gridLayout->addWidget(buttonBox, 9, 0, 1, gridLayout->columnCount());
 
-  closeWindowAction = new QAction(this);
-  closeWindowAction->setShortcut(QKeySequence::Close);
-  this->addAction(closeWindowAction);
-
   this->setLayout(gridLayout);
   this->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::MinimumExpanding);
   this->resize(760, 300);
   this->setWindowTitle(tr("Settings"));
-
-  // Make the dialog pop up above any other windows but retain title bar and buttons
-  Qt::WindowFlags flags = this->windowFlags();
-  flags |= Qt::CustomizeWindowHint | Qt::WindowStaysOnTopHint | Qt::WindowMinMaxButtonsHint |
-           Qt::WindowCloseButtonHint;
-  this->setWindowFlags(flags);
 }
 
 void Settings::wireUi() {
@@ -178,7 +169,6 @@ void Settings::wireUi() {
   connect(buttonBox, &QDialogButtonBox::rejected, this, &Settings::onCancelClicked);
   connect(testConnectionButton, &QPushButton::clicked, this, &Settings::onTestConnectionClicked);
   connect(eviRepoBrowseButton, &QPushButton::clicked, this, &Settings::onBrowseClicked);
-  connect(closeWindowAction, &QAction::triggered, this, &Settings::onSaveClicked);
   connect(clearHotkeysButton, &QPushButton::clicked, this, &Settings::onClearShortcutsClicked);
 
   connect(captureAreaShortcutTextBox, &QKeySequenceEdit::keySequenceChanged, this, [this](const QKeySequence &keySequence){

--- a/src/forms/settings/settings.h
+++ b/src/forms/settings/settings.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <QAction>
+#include "ashirtdialog/ashirtdialog.h"
+
 #include <QCloseEvent>
-#include <QDialog>
 #include <QDialogButtonBox>
 #include <QErrorMessage>
 #include <QGridLayout>
@@ -23,7 +23,7 @@
  * @brief The Settings class represents the settings dialog that displays when
  * a user chooses the "settings" option in the tray menu
  */
-class Settings : public QDialog {
+class Settings : public AShirtDialog {
   Q_OBJECT
 
  public:
@@ -68,7 +68,6 @@ class Settings : public QDialog {
   HotkeyManager* hotkeyManager;
 
   QNetworkReply* currentTestReply = nullptr;
-  QAction* closeWindowAction = nullptr;
 
   // UI components
   QGridLayout* gridLayout = nullptr;


### PR DESCRIPTION
Based on #140 
New Method of Action Creation does not work In Qt5. #143 Will Remove Qt5 Support so no alt path provided for Qt5
Create a new `AShirtDialog` to be used as a common base class for the other dialogs
  - Provides Close action with QKeySequence::Close
  - Optional set window flags
  - Has a show() method later this will be used to clean up the `TrayManager`
  - AShirtDialog::commonWindowFlags is a Qt::WindowFlags of our commonly used flags.