### PR TITLE
Cleanup self better fixes#148

### DIFF
--- a/src/helpers/netman.h
+++ b/src/helpers/netman.h
@@ -43,12 +43,13 @@ class NetMan : public QObject {
  private:
   QNetworkAccessManager *nam;
 
-  NetMan() { nam = new QNetworkAccessManager; }
-  ~NetMan() {
-    delete nam;
-    stopReply(&allOpsReply);
-    stopReply(&githubReleaseReply);
+  NetMan(QObject * parent = nullptr)
+    : QObject(parent)
+    , nam(new QNetworkAccessManager(this))
+  {
+
   }
+  ~NetMan() = default;
 
   /// ashirtGet generates a basic GET request to the ashirt API server. No authentication is
   /// provided (use addASHIRTAuth to do this)


### PR DESCRIPTION
Fixes: #148

- Clean up the NetMan better so it doesn't crash on windows
- Double Check with memcheck no new leaks from the removal of `stopReply` Calls