### PR TITLE
Cleanup tray manager

### DIFF
--- a/src/helpers/hotkeys/uglobalhotkeys.cpp
+++ b/src/helpers/hotkeys/uglobalhotkeys.cpp
@@ -10,8 +10,8 @@
 #include "hotkeymap.h"
 #include "uglobalhotkeys.h"
 
-UGlobalHotkeys::UGlobalHotkeys(QWidget *parent)
-    : QWidget(parent)
+UGlobalHotkeys::UGlobalHotkeys(QObject *parent)
+    : QObject(parent)
 {
 #if defined(Q_OS_LINUX)
     qApp->installNativeEventFilter(this);
@@ -72,7 +72,7 @@ bool UGlobalHotkeys::registerHotkey(const UKeySequence &keySeq, size_t id)
         }
     }
 
-    if (!RegisterHotKey((HWND)winId(), id, winMod, key)) {
+    if (!RegisterHotKey(nullptr, id, winMod, key)) {
         return false;
     } else {
         Registered.insert(id);
@@ -110,7 +110,7 @@ void UGlobalHotkeys::unregisterHotkey(size_t id)
     Q_ASSERT(Registered.find(id) != Registered.end() && "Unregistered hotkey");
 #endif
 #if defined(Q_OS_WIN)
-    UnregisterHotKey((HWND)winId(), id);
+    UnregisterHotKey(nullptr, id);
 #elif defined(Q_OS_LINUX)
     unregLinuxHotkey(id);
 #endif
@@ -147,7 +147,7 @@ UGlobalHotkeys::~UGlobalHotkeys()
 {
 #if defined(Q_OS_WIN)
     for (auto hotKey : qAsConst(Registered)) {
-        UnregisterHotKey((HWND)winId(), hotKey);
+        UnregisterHotKey(nullptr, hotKey);
     }
 #elif defined(Q_OS_LINUX)
     xcb_key_symbols_free(X11KeySymbs);

--- a/src/helpers/hotkeys/uglobalhotkeys.h
+++ b/src/helpers/hotkeys/uglobalhotkeys.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QWidget>
+#include <QObject>
 #include <QAbstractNativeEventFilter>
 #include <QSet>
 
@@ -24,7 +24,7 @@ struct UHotkeyData {
 };
 #endif
 
-class UGlobalHotkeys : public QWidget
+class UGlobalHotkeys : public QObject
 #if defined(Q_OS_LINUX) || defined(Q_OS_WIN)
     , public QAbstractNativeEventFilter
 #endif
@@ -32,7 +32,7 @@ class UGlobalHotkeys : public QWidget
     Q_OBJECT
 
 public:
-    explicit UGlobalHotkeys(QWidget *parent = 0);
+    explicit UGlobalHotkeys(QObject *parent = 0);
     bool registerHotkey(const QString &keySeq, size_t id = 1);
     bool registerHotkey(const UKeySequence &keySeq, size_t id = 1);
     void unregisterHotkey(size_t id = 1);

--- a/src/hotkeymanager.cpp
+++ b/src/hotkeymanager.cpp
@@ -10,8 +10,10 @@
 #include "appsettings.h"
 #include "helpers/hotkeys/uglobalhotkeys.h"
 
-HotkeyManager::HotkeyManager() {
-  hotkeyManager = new UGlobalHotkeys();
+HotkeyManager::HotkeyManager(QObject *parent)
+  : QObject (parent)
+  , hotkeyManager(new UGlobalHotkeys(this))
+{
   connect(hotkeyManager, &UGlobalHotkeys::activated, this, &HotkeyManager::hotkeyTriggered);
 }
 

--- a/src/hotkeymanager.h
+++ b/src/hotkeymanager.h
@@ -16,7 +16,7 @@ class HotkeyManager : public QObject {
   Q_OBJECT
 
  public:
-  HotkeyManager();
+  HotkeyManager(QObject *parent = nullptr);
   ~HotkeyManager();
 
   /// GlobalHotkeyEvent provides names for all possible application-global hotkeys

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,10 +71,10 @@ int main(int argc, char* argv[]) {
     }
     QApplication::setQuitOnLastWindowClosed(false);
 
-    auto window = new TrayManager(conn);
+    auto window = new TrayManager(nullptr, conn);
     rtn = app.exec();
     AppSettings::getInstance().sync();
-    delete window;
+    window->deleteLater();
   }
   catch (std::exception const& ex) {
     std::cout << "Exception while running: " << ex.what() << std::endl;

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -30,14 +30,27 @@
 #include <QSettings>
 #endif
 
+TrayManager::TrayManager(QWidget * parent, DatabaseConnection* db)
+    : QDialog(parent)
+    , db(db)
+    , screenshotTool(new Screenshot(this))
+    , hotkeyManager(new HotkeyManager())
+    , updateCheckTimer(new QTimer(this))
+    , settingsWindow(new Settings(hotkeyManager, this))
+    , evidenceManagerWindow(new EvidenceManager(this->db, this))
+    , creditsWindow(new Credits(this))
+    , importWindow(new PortingDialog(PortingDialog::Import, this->db, this))
+    , exportWindow(new PortingDialog(PortingDialog::Export, this->db, this))
+    , createOperationWindow(new CreateOperation(this))
+    , currentOperationMenuAction(new QAction(QString(), this))
+    , chooseOpStatusAction(new QAction(tr("Loading operations..."), this))
+    , newOperationAction(new QAction(tr("New Operation"), this))
+    , trayIcon(new QSystemTrayIcon(getTrayIcon(),this))
+    , allOperationActions(this)
 
-TrayManager::TrayManager(DatabaseConnection* db) {
-  this->db = db;
-  screenshotTool = new Screenshot();
-  hotkeyManager = new HotkeyManager();
+{
   hotkeyManager->updateHotkeys();
-  updateCheckTimer = new QTimer(this);
-  updateCheckTimer->start(24*60*60*1000); // every day
+  updateCheckTimer->start(MS_IN_DAY); // every day
 
   buildUi();
   wireUi();
@@ -49,112 +62,47 @@ TrayManager::TrayManager(DatabaseConnection* db) {
 
 TrayManager::~TrayManager() {
   setVisible(false);
-
-  delete exportAction;
-  delete importAction;
-
-  delete quitAction;
-  delete showSettingsAction;
-  delete currentOperationMenuAction;
-  delete captureScreenAreaAction;
-  delete captureWindowAction;
-  delete showEvidenceManagerAction;
-  delete showCreditsAction;
-  delete addCodeblockAction;
-  cleanChooseOpSubmenu();  // must be done before deleting chooseOpSubmenu/action
-
-  delete chooseOpStatusAction;
-  delete chooseOpSubmenu;
-  delete importExportSubmenu;
-
-  delete updateCheckTimer;
-  delete trayIconMenu;
-  delete trayIcon;
-
-  delete screenshotTool;
-  delete hotkeyManager;
-  delete settingsWindow;
-  delete evidenceManagerWindow;
-  delete importWindow;
-  delete exportWindow;
-  delete creditsWindow;
+  cleanChooseOpSubmenu();
 }
 
 void TrayManager::buildUi() {
-  // create subwindows
-  settingsWindow = new Settings(hotkeyManager, this);
-  evidenceManagerWindow = new EvidenceManager(db, this);
-  creditsWindow = new Credits(this);
-  importWindow = new PortingDialog(PortingDialog::Import, db, this);
-  exportWindow = new PortingDialog(PortingDialog::Export, db, this);
-  createOperationWindow = new CreateOperation(this);
-
-  trayIconMenu = new QMenu(this);
-
-  auto addMenuToMenu = [this](const QString& text, QMenu** submenu, QMenu** parent) {
-    *submenu = new QMenu(text, this);
-    (*parent)->addMenu(*submenu);
-  };
-
-  // small helper to create an action and assign it to a menu
-  auto addToMenu = [this](const QString& text, QAction** act, QMenu** menu) {
-    *act = new QAction(text, this);
-    (*menu)->addAction(*act);
-  };
-
-  // Tray menu
-  addToMenu(tr("Add Codeblock from Clipboard"), &addCodeblockAction, &trayIconMenu);
-  addToMenu(tr("Capture Screen Area"), &captureScreenAreaAction, &trayIconMenu);
-  addToMenu(tr("Capture Window"), &captureWindowAction, &trayIconMenu);
-  addToMenu(tr("View Accumulated Evidence"), &showEvidenceManagerAction, &trayIconMenu);
-  trayIconMenu->addSeparator();
-  addToMenu(QString(), &currentOperationMenuAction, &trayIconMenu);
-  addMenuToMenu(tr("Select Operation"), &chooseOpSubmenu, &trayIconMenu);
-  trayIconMenu->addSeparator();
-  addMenuToMenu(tr("Import/Export"), &importExportSubmenu, &trayIconMenu);
-  addToMenu(tr("Settings"), &showSettingsAction, &trayIconMenu);
-  addToMenu(tr("About"), &showCreditsAction, &trayIconMenu);
-  addToMenu(tr("Quit"), &quitAction, &trayIconMenu);
-
-  // Operations Submenu
+  //Disable Actions
   currentOperationMenuAction->setEnabled(false);
-  addToMenu(tr("Loading operations..."), &chooseOpStatusAction, &chooseOpSubmenu);
-  addToMenu(tr("New Operation"), &newOperationAction, &chooseOpSubmenu);
-
   chooseOpStatusAction->setEnabled(false);
   newOperationAction->setEnabled(false);  // only enable when we have an internet connection
+
+  // Build Tray menu
+  auto trayIconMenu = new QMenu(this);
+  trayIconMenu->addAction(tr("Add Codeblock from Clipboard"), this, &TrayManager::captureCodeblockActionTriggered);
+  trayIconMenu->addAction(tr("Capture Screen Area"), this, &TrayManager::captureAreaActionTriggered);
+  trayIconMenu->addAction(tr("Capture Window"), this, &TrayManager::captureWindowActionTriggered);
+  trayIconMenu->addAction(tr("View Accumulated Evidence"), evidenceManagerWindow, &EvidenceManager::show);
+  trayIconMenu->addSeparator();
+  trayIconMenu->addAction(currentOperationMenuAction);
+  chooseOpSubmenu = trayIconMenu->addMenu(tr("Select Operation"));
+  trayIconMenu->addSeparator();
+  auto importExportSubmenu = trayIconMenu->addMenu(tr("Import/Export"));
+  trayIconMenu->addAction(tr("Settings"), settingsWindow, &Settings::show);
+  trayIconMenu->addAction(tr("About"), creditsWindow, &Credits::show);
+  trayIconMenu->addAction(tr("Quit"), qApp, &QCoreApplication::quit);
+
+  // Operations Submenu
+  chooseOpSubmenu->addAction(chooseOpStatusAction);
+  chooseOpSubmenu->addAction(newOperationAction);
   chooseOpSubmenu->addSeparator();
 
   // settings submenu
-
-  addToMenu(tr("Export Data"), &exportAction, &importExportSubmenu);
-  addToMenu(tr("Import Data"), &importAction, &importExportSubmenu);
+  importExportSubmenu->addAction(tr("Export Data"), exportWindow, &PortingDialog::show);
+  importExportSubmenu->addAction(tr("Import Data"), importWindow, &PortingDialog::show);
 
   setActiveOperationLabel();
 
-  trayIcon = new QSystemTrayIcon(getTrayIcon(), this);
   trayIcon->setContextMenu(trayIconMenu);
   trayIcon->show();
 }
 
 void TrayManager::wireUi() {
-  auto toTop = [](QDialog* window) {
-    window->show(); // display the window
-    window->raise(); // bring to the top (mac)
-    window->activateWindow(); // alternate bring to the top (windows)
-  };
-  auto actTriggered = &QAction::triggered;
-  // connect actions
-  connect(quitAction, actTriggered, qApp, &QCoreApplication::quit);
-  connect(exportAction, actTriggered, this, [this, toTop](){toTop(exportWindow);});
-  connect(importAction, actTriggered, this, [this, toTop](){toTop(importWindow);});
-  connect(showSettingsAction, actTriggered, this, [this, toTop](){toTop(settingsWindow);});
-  connect(captureScreenAreaAction, actTriggered, this, &TrayManager::captureAreaActionTriggered);
-  connect(captureWindowAction, actTriggered, this, &TrayManager::captureWindowActionTriggered);
-  connect(showEvidenceManagerAction, actTriggered, this, [this, toTop](){toTop(evidenceManagerWindow);});
-  connect(showCreditsAction, actTriggered, this, [this, toTop](){toTop(creditsWindow);});
-  connect(addCodeblockAction, actTriggered, this, &TrayManager::captureCodeblockActionTriggered);
-  connect(newOperationAction, actTriggered, this, [this, toTop](){toTop(createOperationWindow);});
+  connect(newOperationAction, &QAction::triggered, createOperationWindow, &CreateOperation::show);
 
   connect(exportWindow, &PortingDialog::portCompleted, this, [this](const QString& path) {
     openServicesPath = path;
@@ -194,11 +142,10 @@ void TrayManager::wireUi() {
 
 void TrayManager::cleanChooseOpSubmenu() {
   // delete all of the existing events
-  for (QAction* act : allOperationActions) {
+  for (auto act : allOperationActions.actions()) {
     chooseOpSubmenu->removeAction(act);
-    delete act;
+    allOperationActions.removeAction(act);
   }
-  allOperationActions.clear();
   selectedAction = nullptr; // clear the selected action to ensure no funny business
 }
 
@@ -216,7 +163,6 @@ void TrayManager::closeEvent(QCloseEvent* event) {
 
 void TrayManager::changeEvent(QEvent *event)
 {
-    qDebug() <<"EVENT" <<  event->type() << " " << event->spontaneous();
     if (event->type() == QEvent::ApplicationPaletteChange) {
         trayIcon->setIcon(getTrayIcon());
         QWidget::event(event);
@@ -313,29 +259,23 @@ void TrayManager::onOperationListUpdated(bool success,
     cleanChooseOpSubmenu();
 
     for (const auto& op : operations) {
-      auto newAction = new QAction(op.name, chooseOpSubmenu);
-
+      auto newAction = std::make_shared<QAction>(new QAction(this));
+      newAction->setText(op.name);
+      newAction->setCheckable(true);
       if (currentOp == op.slug) {
-        newAction->setCheckable(true);
         newAction->setChecked(true);
-        selectedAction = newAction;
+        selectedAction = newAction.get();
       }
+      allOperationActions.addAction(newAction.get());
 
-      connect(newAction, &QAction::triggered, this, [this, newAction, op] {
+      connect(newAction.get(), &QAction::triggered, this, [this, newAction, op] {
         AppSettings::getInstance().setLastUsedTags(QList<model::Tag>{}); // clear last used tags
         AppSettings::getInstance().setOperationDetails(op.slug, op.name);
-        if (selectedAction != nullptr) {
-          selectedAction->setChecked(false);
-          selectedAction->setCheckable(false);
-        }
-        newAction->setCheckable(true);
-        newAction->setChecked(true);
-        selectedAction = newAction;
+        selectedAction = newAction.get();
       });
-      allOperationActions.append(newAction);
-      chooseOpSubmenu->addAction(newAction);
+      chooseOpSubmenu->addAction(newAction.get());
     }
-    if (selectedAction == nullptr) {
+    if (!selectedAction) {
       AppSettings::getInstance().setOperationDetails(QString(), QString());
     }
   }
@@ -363,7 +303,7 @@ void TrayManager::onReleaseCheck(bool success, const QList<dto::GithubRelease>& 
 void TrayManager::setTrayMessage(MessageType type, const QString& title, const QString& message,
                                  QSystemTrayIcon::MessageIcon icon, int millisecondsTimeoutHint) {
   trayIcon->showMessage(title, message, icon, millisecondsTimeoutHint);
-  this->currentTrayMessage = type;
+  currentTrayMessage = type;
 }
 
 QIcon TrayManager::getTrayIcon()

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -34,7 +34,7 @@ TrayManager::TrayManager(QWidget * parent, DatabaseConnection* db)
     : QDialog(parent)
     , db(db)
     , screenshotTool(new Screenshot(this))
-    , hotkeyManager(new HotkeyManager())
+    , hotkeyManager(new HotkeyManager(this))
     , updateCheckTimer(new QTimer(this))
     , settingsWindow(new Settings(hotkeyManager, this))
     , evidenceManagerWindow(new EvidenceManager(this->db, this))
@@ -262,6 +262,7 @@ void TrayManager::onOperationListUpdated(bool success,
       auto newAction = std::make_shared<QAction>(new QAction(this));
       newAction->setText(op.name);
       newAction->setCheckable(true);
+
       if (currentOp == op.slug) {
         newAction->setChecked(true);
         selectedAction = newAction.get();

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <QActionGroup>
 #include <QSystemTrayIcon>
 #include <QTimer>
 
@@ -51,7 +52,7 @@ class TrayManager : public QDialog {
   Q_OBJECT
 
  public:
-  TrayManager(DatabaseConnection *);
+  TrayManager(QWidget* parent = nullptr, DatabaseConnection *db = nullptr);
   ~TrayManager();
 
  private:
@@ -67,6 +68,7 @@ class TrayManager : public QDialog {
   void setTrayMessage(MessageType type, const QString& title, const QString& message,
                       QSystemTrayIcon::MessageIcon icon=QSystemTrayIcon::Information, int millisecondsTimeoutHint = 10000);
   QIcon getTrayIcon();
+
  private slots:
   void onOperationListUpdated(bool success, const QList<dto::Operation> &operations);
   void onReleaseCheck(bool success, const QList<dto::GithubRelease>& releases);
@@ -85,6 +87,7 @@ class TrayManager : public QDialog {
   void changeEvent(QEvent *event) override;
 
  private:
+  inline static const int MS_IN_DAY = 86400000;
   DatabaseConnection *db = nullptr;
   HotkeyManager *hotkeyManager = nullptr;
   Screenshot *screenshotTool = nullptr;
@@ -104,25 +107,11 @@ class TrayManager : public QDialog {
 
   // UI Elements
   QSystemTrayIcon *trayIcon = nullptr;
-  QMenu *trayIconMenu = nullptr;
-
-  QAction *quitAction = nullptr;
   QAction *currentOperationMenuAction = nullptr;
-  QAction *captureScreenAreaAction = nullptr;
-  QAction *captureWindowAction = nullptr;
-  QAction *showEvidenceManagerAction = nullptr;
-  QAction *showCreditsAction = nullptr;
-  QAction *addCodeblockAction = nullptr;
-
-  QMenu *importExportSubmenu = nullptr;
-  QAction *exportAction = nullptr;
-  QAction *importAction = nullptr;
-  QAction *showSettingsAction = nullptr;
-
   QMenu *chooseOpSubmenu = nullptr;
   QAction *chooseOpStatusAction = nullptr;
   QAction *newOperationAction = nullptr;
   QAction *selectedAction = nullptr;  // note: do not delete; for reference only
-  QList<QAction *> allOperationActions;
+  QActionGroup allOperationActions;
 };
 #endif  // QT_NO_SYSTEMTRAYICON

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -107,9 +107,7 @@ class TrayManager : public QDialog {
 
   // UI Elements
   QSystemTrayIcon *trayIcon = nullptr;
-  QAction *currentOperationMenuAction = nullptr;
   QMenu *chooseOpSubmenu = nullptr;
-  QAction *chooseOpStatusAction = nullptr;
   QAction *newOperationAction = nullptr;
   QAction *selectedAction = nullptr;  // note: do not delete; for reference only
   QActionGroup allOperationActions;


### PR DESCRIPTION
- Clean up the Tray manager
- Removes a memory leak related to action selection changing.
- Use `QActionGroup` in place of `QList<QAction*>`  for the operations Actions
- UI Changes
  - Remove the disabled actions
  - Use actionNewOperation label to show when disconnected from server
  - chooseOpSubMenu Title will show current op
  - Prevew: Server Connected (Indicator style is DE Dependent)
  ![Screenshot_20220505_071056](https://user-images.githubusercontent.com/98421672/166969782-be794c63-1fac-4338-8c2d-0ffd9b6850a7.png)
   - Prevew: No Server Connected
   ![Screenshot_20220505_071004](https://user-images.githubusercontent.com/98421672/166969844-d67ff58c-db16-4979-9921-f17bbc0ea1c3.png)



