### PR TITLE
Normalize temp path for screenshots

### DIFF
--- a/src/helpers/screenshot.cpp
+++ b/src/helpers/screenshot.cpp
@@ -46,7 +46,7 @@ void Screenshot::basicScreenshot(QString cmdProto) {
   auto hasPath = QDir().mkpath(root);
 
   if (hasPath) {
-    auto tempPath = QStringLiteral("%1/%2").arg(QDir::tempPath(), mkName());
+    auto tempPath = QDir::toNativeSeparators(QStringLiteral("%1/%2").arg(QDir::tempPath(), mkName()));
 
     QString cmd = formatScreenshotCmd(std::move(cmdProto), tempPath);
     auto lastSlash = tempPath.lastIndexOf(QStringLiteral("/")) + 1;

--- a/src/helpers/screenshot.cpp
+++ b/src/helpers/screenshot.cpp
@@ -26,7 +26,11 @@ QString Screenshot::formatScreenshotCmd(QString cmdProto, const QString &filenam
   if (idx == -1) {
     return cmdProto;
   }
-  QString fixedFilename = QStringLiteral("'%1'").arg(filename);
+  #ifdef Q_OS_WIN
+    QString fixedFilename = QStringLiteral("\"%1\"").arg(filename);
+  #else
+    QString fixedFilename = QStringLiteral("'%1'").arg(filename);
+  #endif
   return cmdProto.replace(idx, key.length(), fixedFilename);
 }
 


### PR DESCRIPTION
The temp filename does not use backslashes on windows. This is an attempt at a simple fix.

- Please review our [contributing guidelines](https://github.com/theparanoids/ashirt/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/ashirt/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.