### PR TITLE
Use QProcess to start screenshot tool

### DIFF
--- a/src/helpers/screenshot.h
+++ b/src/helpers/screenshot.h
@@ -4,23 +4,24 @@
 #pragma once
 
 #include <QObject>
-#include <string>
 
 class Screenshot : public QObject {
   Q_OBJECT
  public:
-  Screenshot(QObject* parent = 0);
+  Screenshot(QObject* parent = nullptr);
   void captureArea();
   void captureWindow();
 
   static QString mkName();
-  static QString extension();
-  static QString contentType();
+  static QString extension() { return QStringLiteral("png"); }
+  static QString contentType() { return QStringLiteral("image"); }
 
  signals:
   void onScreenshotCaptured(QString filepath);
 
  private:
-  QString formatScreenshotCmd(QString cmdProto, const QString& filename);
   void basicScreenshot(QString cmdProto);
+  inline static const QString m_fileTemplate = QStringLiteral("%1/%2");
+  inline static const QString m_doubleQuote = QStringLiteral("\"");
+  inline static const QString m_space = QStringLiteral(" ");
 };


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Replace The System call with QProcess. Allow for the programs path to be wrapped in  Quotes 
Remove uneeded methods from screenshot object
SuperSeeds #175  Fixes: #176 