### PR TITLE
Cleanup ui_helpers

### DIFF
--- a/src/components/code_editor/codeblockview.cpp
+++ b/src/components/code_editor/codeblockview.cpp
@@ -1,6 +1,8 @@
 #include "codeblockview.h"
 
 #include <QComboBox>
+#include <QGridLayout>
+#include <QLabel>
 #include <QLineEdit>
 
 #include "codeeditor.h"
@@ -49,7 +51,7 @@ void CodeBlockView::loadFromFile(QString filepath) {
 
     codeEditor->setPlainText(loadedCodeblock.content);
     sourceTextBox->setText(loadedCodeblock.source);
-    UiHelpers::setComboBoxValue(languageComboBox, loadedCodeblock.subtype);
+    UIHelpers::setComboBoxValue(languageComboBox, loadedCodeblock.subtype);
   }
   catch (std::exception& e) {
     QString msg = tr("Unable to load codeblock. Error: %1").arg(e.what());

--- a/src/components/code_editor/codeblockview.h
+++ b/src/components/code_editor/codeblockview.h
@@ -50,7 +50,6 @@ class CodeBlockView : public EvidencePreview {
   CodeEditor* codeEditor = nullptr;
   QLineEdit* sourceTextBox = nullptr;
   QComboBox* languageComboBox = nullptr;
-
   // matches supported languages on the front end
   inline static const QList<QPair<QString, QString>> SUPPORTED_LANGUAGES = {
       QPair<QString, QString>(QStringLiteral("Plain Text"), QString()),

--- a/src/forms/evidence_filter/evidencefilterform.cpp
+++ b/src/forms/evidence_filter/evidencefilterform.cpp
@@ -7,6 +7,7 @@
 #include <QCheckBox>
 #include <QDateEdit>
 #include <QDialogButtonBox>
+#include <QGridLayout>
 #include <QLabel>
 
 #include "appsettings.h"
@@ -161,8 +162,8 @@ EvidenceFilters EvidenceFilterForm::encodeForm() {
 }
 
 void EvidenceFilterForm::setForm(const EvidenceFilters &model) {
-  UiHelpers::setComboBoxValue(operationComboBox, model.operationSlug);
-  UiHelpers::setComboBoxValue(contentTypeComboBox, model.contentType);
+  UIHelpers::setComboBoxValue(operationComboBox, model.operationSlug);
+  UIHelpers::setComboBoxValue(contentTypeComboBox, model.contentType);
   erroredComboBox->setCurrentText(EvidenceFilters::triToString(model.hasError));
   submittedComboBox->setCurrentText(EvidenceFilters::triToString(model.submitted));
 
@@ -191,6 +192,6 @@ void EvidenceFilterForm::onOperationListUpdated(bool success,
   for (const auto &op : operations) {
     operationComboBox->addItem(op.name, op.slug);
   }
-  UiHelpers::setComboBoxValue(operationComboBox, AppSettings::getInstance().operationSlug());
+  UIHelpers::setComboBoxValue(operationComboBox, AppSettings::getInstance().operationSlug());
   operationComboBox->setEnabled(true);
 }

--- a/src/forms/getinfo/getinfo.cpp
+++ b/src/forms/getinfo/getinfo.cpp
@@ -3,6 +3,7 @@
 
 #include "getinfo.h"
 
+#include <QGridLayout>
 #include <QMessageBox>
 
 #include "appsettings.h"
@@ -11,7 +12,6 @@
 #include "db/databaseconnection.h"
 #include "helpers/netman.h"
 #include "helpers/stopreply.h"
-#include "helpers/ui_helpers.h"
 
 GetInfo::GetInfo(DatabaseConnection* db, qint64 evidenceID, QWidget* parent)
     : AShirtDialog(parent, AShirtDialog::commonWindowFlags)

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -22,7 +22,6 @@
 #include "helpers/http_status.h"
 #include "helpers/netman.h"
 #include "helpers/stopreply.h"
-#include "helpers/ui_helpers.h"
 #include "hotkeymanager.h"
 #include "components/custom_keyseq_edit/singlestrokekeysequenceedit.h"
 #include "components/loading_button/loadingbutton.h"

--- a/src/helpers/ui_helpers.h
+++ b/src/helpers/ui_helpers.h
@@ -1,63 +1,11 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QComboBox>
-#include <QGridLayout>
-#include <QHBoxLayout>
-#include <QLabel>
-#include <QWidget>
-
-class UiHelpers {
+class UIHelpers {
  public:
-  /**
-   * @brief overlapPlaceholder Adds a component in the same position as the "placeholder" widget
-   * @param placeholder The QWidget to overlap
-   * @param replacement The QWidget that will overlap the placeholder
-   * @param layout Where _both_ QWidgets should live
-   */
-  static void overlapPlaceholder(QWidget* placeholder, QWidget* replacement, QGridLayout* layout) {
-    int row, col, rSpan, cSpan;
-    auto widgetIndex = layout->indexOf(placeholder);
-    if (widgetIndex == -1) {
-      throw std::runtime_error("Placeholder is not contained in layout");
-    }
-    layout->getItemPosition(widgetIndex, &row, &col, &rSpan, &cSpan);
-    layout->addWidget(replacement, row, col, rSpan, cSpan);
-  }
-
-  /**
-   * @brief replacePlaceholder Replaces the _placeholder_ component with the _replacement_
-   * component. The original/placeholder component is hidden and removed from the layout
-   * @param placeholder The QWidget to remove
-   * @param replacement The QWidget to add in the placeholder's position
-   * @param layout Where the placeholder lives, and where the replacement will live
-   */
-  static void replacePlaceholder(QWidget* placeholder, QWidget* replacement, QGridLayout* layout) {
-    overlapPlaceholder(placeholder, replacement, layout);
-    placeholder->setVisible(false);
-    layout->removeWidget(placeholder);
-  }
-
-  /**
-   * @brief setComboBoxValue Sets a combobox's value based on the supplied _value_. Sets the value
-   * to the proper index if found, otherwise sets the index to 0 if not found. Note: this does a
-   * linear search for values, so may not be appropriate for all boxen.
-   * @param box The source combobox
-   * @param value The value to search for in the combobox
-   */
-  static void setComboBoxValue(QComboBox* box, const QString& value) {
-    bool found = false;
-    for (int i = 0; i < box->count(); i++) {
-      if (box->itemData(i) == value) {
-        box->setCurrentIndex(i);
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
-      box->setCurrentIndex(0);
-    }
+  ///setCurrentValueFromData sets a comboBoxes currentIndex based on a "data" value
+  ///Unlike findData the index 0 is returned if the item is not found.
+  static void setComboBoxValue(QComboBox *box, QString dataValue) {
+    box->setCurrentIndex(std::max(0, box->findData(dataValue)));
   }
 };


### PR DESCRIPTION
 - Clean up Ui_helpers 
   - Only method in use is `UIHelpers:::setComboBoxValue(QComboBox * box, QString value)`
   - Simplify the method
