### PR TITLE
CleanerError and warning output

### DIFF
--- a/src/dtos/github_release.h
+++ b/src/dtos/github_release.h
@@ -132,7 +132,7 @@ class ReleaseDigest {
   static ReleaseDigest fromReleases(QString curVersion, const QList<GithubRelease> &borrowedReleases) {
 
     if (curVersion.contains(QStringLiteral("v0.0.0"))) {
-      QTextStream(stdout) << "skipping unversioned/development release check" << Qt::endl;
+      qInfo() << "skipping unversioned/development release check";
       return ReleaseDigest();
     }
 

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -264,10 +264,10 @@ void EvidenceManager::deleteSet(QList<qint64> ids) {
   }
 
   if (!removedAllDbRecords) {
-    QTextStream(stderr) << "Could not delete evidence from internal database. Errors: " << Qt::endl;
+    qWarning() << "Could not delete evidence from internal database. Errors: ";
     for (const auto& resp : responses) {
       if (!resp.dbDeleteSuccess) {
-        QTextStream(stderr) << "  id: " << resp.model.id << " ;; Error: "<< resp.errorText << Qt::endl;
+        qWarning() << "  id: " << resp.model.id << " ;; Error: "<< resp.errorText;
       }
     }
   }
@@ -380,8 +380,7 @@ void EvidenceManager::loadEvidence() {
     }
   }
   catch (QSqlError& e) {
-    QTextStream(stderr) << "Could not retrieve evidence for operation. Error: " << e.text()
-              << Qt::endl;
+    qWarning() << "Could not retrieve evidence for operation. Error: " << e.text();
   }
 }
 
@@ -439,7 +438,7 @@ void EvidenceManager::refreshRow(int row) {
     setRowText(row, updatedData);
   }
   catch (QSqlError& e) {
-    QTextStream(stderr) << "Could not refresh table row: " << e.text() << Qt::endl;
+    qWarning() << "Could not refresh table row: " << e.text();
   }
 }
 
@@ -506,8 +505,7 @@ void EvidenceManager::onUploadComplete() {
       db->updateEvidenceError(errMessage, evidenceIDForRequest);
     }
     catch (QSqlError& e) {
-      QTextStream(stderr) << "Upload failed. Could not update internal database. Error: "
-                << e.text() << Qt::endl;
+      qWarning() << "Upload failed. Could not update internal database. Error: " << e.text();
     }
     QMessageBox::warning(this, tr("Cannot Submit Evidence"),
                          tr("Upload failed: Network error. Check your connection and try again.\n"
@@ -518,8 +516,7 @@ void EvidenceManager::onUploadComplete() {
       db->updateEvidenceSubmitted(evidenceIDForRequest);
     }
     catch (QSqlError& e) {
-      QTextStream(stderr) << "Upload successful. Could not update internal database. Error: "
-                << e.text() << Qt::endl;
+      qWarning() << "Upload successful. Could not update internal database. Error: " << e.text();
     }
     Q_EMIT evidenceChanged(evidenceIDForRequest, true);  // lock the editing form
   }

--- a/src/forms/getinfo/getinfo.cpp
+++ b/src/forms/getinfo/getinfo.cpp
@@ -136,8 +136,7 @@ void GetInfo::onUploadComplete() {
       db->updateEvidenceError(errMessage, evidenceID);
     }
     catch (QSqlError& e) {
-      QTextStream(stderr) << "Upload failed. Could not update internal database. Error: "
-                << e.text() << Qt::endl;
+      qWarning() << "Upload failed. Could not update internal database. Error: " << e.text();
     }
     QMessageBox::warning(this, tr("Cannot submit evidence"),
                          tr("Upload failed: Network error. Check your connection and try again.\n"
@@ -152,8 +151,7 @@ void GetInfo::onUploadComplete() {
       close();
     }
     catch (QSqlError& e) {
-      QTextStream(stderr) << "Upload successful. Could not update internal database. Error: "
-                << e.text() << Qt::endl;
+      qWarning() << "Upload successful. Could not update internal database. Error: " << e.text();
     }
   }
   // we don't actually need anything from the uploadAssets reply, so just clean it up.

--- a/src/helpers/file_helpers.h
+++ b/src/helpers/file_helpers.h
@@ -30,7 +30,7 @@ class FileHelpers {
     if (file.open(QIODevice::ReadOnly))
         data = file.readAll();
     if (file.error() != QFile::NoError)
-      QTextStream(stderr) << "Unable to read from file: " << path << '\n' << file.error();
+      qWarning() << "Unable to read from file: " << path << '\n' << file.error();
     return data;
   }
 

--- a/src/helpers/netman.h
+++ b/src/helpers/netman.h
@@ -123,7 +123,7 @@ public:
   /// Callers should retrieve the result by listening for the releasesChecked signal
   static void checkForNewRelease(QString owner, QString repo) {
     if (owner.isEmpty() || repo.isEmpty()) {
-      QTextStream(stderr) << "Skipping release check: no owner or repo set." << Qt::endl;
+      qWarning() << "Skipping release check: no owner or repo set.";
       return;
     }
     get()->githubReleaseReply = get()->getGithubReleases(owner, repo);

--- a/src/helpers/request_builder.h
+++ b/src/helpers/request_builder.h
@@ -181,7 +181,7 @@ class RequestBuilder {
         reply = nam->post(req, body);
         break;
       default:
-        QTextStream(stderr) << "Requestbuilder contains an unsupported request method" << Qt::endl;
+        qWarning() << "Requestbuilder contains an unsupported request method";
     }
     if (autodelete) {
       delete this;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,16 +31,15 @@ int main(int argc, char* argv[]) {
   QCoreApplication::setOrganizationName("ashirt");
 #endif
 
-
   DatabaseConnection* conn = new DatabaseConnection(Constants::dbLocation, Constants::defaultDbName);
-  if(!conn->connect()) {
-    QTextStream(stderr) << "Unable to connect to Database" << Qt::endl;
+  if (!conn->connect()) {
+    QMessageBox::critical(nullptr, QStringLiteral("ASHIRT Error"), QStringLiteral("Unable to connect to database"));
     return -1;
   }
 
   auto configError = AppConfig::getInstance().errorText;
   if (!configError.isEmpty()) {  // quick check & preload config data
-    QTextStream(stderr) << "Unable to load config file: " << configError << Qt::endl;
+    QMessageBox::critical(nullptr, QStringLiteral("ASHIRT Error"), QStringLiteral("Unable to connect to load settings"));
     return -1;
   }
 
@@ -67,10 +66,10 @@ int main(int argc, char* argv[]) {
     window->deleteLater();
   }
   catch (std::exception const& ex) {
-    QTextStream(stderr) << "Exception while running: " << ex.what() << Qt::endl;
+    qWarning() << "Exception while running: " << ex.what();
   }
   catch (...) {
-    QTextStream(stderr) << "Unhandled exception while running" << Qt::endl;
+    qWarning() << "Unhandled exception while running";
   }
   return rtn;
 }
@@ -90,14 +89,14 @@ int main(int argc, char *argv[]) { handleCLI(std::vector<string>(argv, argv + ar
 
 void handleCLI(std::vector<std::string> args) {
   size_t trueCount = args.size() - 1;
-  QTextStream(stdout) << "You provided " << trueCount << " arguments.\n";
+  qInfo() << "You provided " << trueCount << " arguments";
   if (trueCount == 0) {
-    QTextStream(stdout) << "Next time try suppling some arguments." << Qt::endl;
+    qInfo() << "Next time try suppling some arguments.";
     return;
   }
 
-  QTextStream(stdout) << "All arguments:" << Qt::endl;
+  qInfo() << "All arguments:";
   for (size_t i = 1; i < args.size(); i++) {
-    QTextStream(stdout) << "\t" << QString::fromStdString(args.at(i)) << Qt::endl;
+    qInfo() << "\t" << QString::fromStdString(args.at(i));
   }
 }

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -216,7 +216,7 @@ void TrayManager::onClipboardCapture()
             return;
         Codeblock evidence(clipboardContent);
         if(!Codeblock::saveCodeblock(evidence)) {
-            QTextStream(stderr) << "Error Gathering Evidence from clipboard" << Qt::endl;
+            setTrayMessage(NO_ACTION, _recordErrorTitle, tr("Error Gathering Evidence from clipboard"), QSystemTrayIcon::Information);
             return;
         }
         path = evidence.filePath();
@@ -235,7 +235,7 @@ void TrayManager::onClipboardCapture()
         evidenceID = createNewEvidence(path, type);
     }
     catch (QSqlError& e) {
-      QTextStream(stderr) << "could not write to the database: " << e.text() << Qt::endl;
+      showDBWriteErrorTrayMessage(e.text());
       return;
     }
     spawnGetInfoWindow(evidenceID);
@@ -247,12 +247,17 @@ void TrayManager::onScreenshotCaptured(const QString& path) {
     spawnGetInfoWindow(evidenceID);
   }
   catch (QSqlError& e) {
-    QTextStream(stderr) << "could not write to the database: " << e.text() << Qt::endl;
+    showDBWriteErrorTrayMessage(e.text());
   }
 }
 
+void TrayManager::showDBWriteErrorTrayMessage(const QString &errorMessage)
+{
+    setTrayMessage(NO_ACTION, _recordErrorTitle, tr("Could not write to database: %1").arg(errorMessage), QSystemTrayIcon::Warning);
+}
+
 void TrayManager::showNoOperationSetTrayMessage() {
-  setTrayMessage(NO_ACTION, tr("Unable to Record Evidence"),
+  setTrayMessage(NO_ACTION, _recordErrorTitle,
                         tr("No Operation has been selected. Please select an operation first."),
                         QSystemTrayIcon::Warning);
 }

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -61,6 +61,7 @@ class TrayManager : public QDialog {
   qint64 createNewEvidence(const QString& filepath, const QString& evidenceType);
   void spawnGetInfoWindow(qint64 evidenceID);
   void showNoOperationSetTrayMessage();
+  void showDBWriteErrorTrayMessage(const QString &errorMessage = QString());
   void checkForUpdate();
   void cleanChooseOpSubmenu();
   /// setTrayMessage mostly mirrors QSystemTrayIcon::showMessage, but adds the ability to set a message type,
@@ -88,6 +89,7 @@ class TrayManager : public QDialog {
 
  private:
   inline static const int MS_IN_DAY = 86400000;
+  QString _recordErrorTitle = tr("Unable to Record Evidence");
   DatabaseConnection *db = nullptr;
   HotkeyManager *hotkeyManager = nullptr;
   Screenshot *screenshotTool = nullptr;


### PR DESCRIPTION
Cleanup the Error and warning output
 - Replace QTextStream(stdout) with qInfo()
 - Replace QTextSteam(stderr) with qWarning()
 - Replace DB Errors in Tray manager with Tray messages
 - Show Message box when main is about to quit if can't open needed items.