### PR TITLE
fix sql query building

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,7 +127,7 @@ jobs:
       shell: bash
       run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
-            sudo apt-get update > /dev/null && sudo apt-get install -qqq libxcb-keysyms1-dev libxkbcommon-dev > /dev/null
+            sudo apt-get update > /dev/null && sudo apt-get install -qqq libxcb-keysyms1-dev libxkbcommon-dev libxkbcommon-x11-dev > /dev/null
         elif [ "$RUNNER_OS" == "Windows" ]; then
             choco install ninja --ignore-checksums
         fi

--- a/src/db/databaseconnection.cpp
+++ b/src/db/databaseconnection.cpp
@@ -194,9 +194,8 @@ bool DatabaseConnection::setEvidenceTags(const QList<model::Tag> &newTags, qint6
   // sqlite indicates it's default is 100 passed parameter, but it can "handle thousands"
   if (!tagDataToInsert.empty()) {
     QVariantList args;
-    baseQuery.append(QStringLiteral("(?, ?, ?"));
+    baseQuery.append(QStringLiteral("(?,?,?)"));
     baseQuery.append(QString(", (?,?,?)").repeated(int(tagDataToInsert.size() - 1)));
-    baseQuery.append(QStringLiteral(")"));
     for (const auto &item : tagDataToInsert) {
       args.append(item.evidenceID);
       args.append(item.tagID);


### PR DESCRIPTION
This PR corrects how the SQL query is built to add evidence with multiple tags.

Somewhere along the way, a refactor changed how tags were inserted. Basically, we kept adding sets of triples, like so: `(?,?,?)` (appending `, (?,?,?)` for each new tag). Then, we broke it by doing this: `(?,?,?`, with `, (?,?,?)` for each new tag, then finally `)`)

With the old way, our query would ultimately look like: `VALUES (?,?,?), (?,?,?), ...`
With the new way, our query would ultimately look like this: `VALUES (?,?,?, (?,?,?), ...)`  <-- I don't think this is valid SQL

This fix just reverts to the old way. 

Note: I'm pretty confident this will work for all environments, but I only explicitly tested on linux.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.