### PR TITLE
Improve app config

### DIFF
--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -106,7 +106,7 @@ QString AppConfig::defaultValue(const QString &key)
 
     if (key == CONFIG::SHORTCUT_CAPTURECLIPBOARD)
 #ifdef Q_OS_LINUX
-        return QString();
+        return QStringLiteral("Meta+Alt+v");
 #elif defined Q_OS_WIN
         return QStringLiteral("Alt+v");
 #elif defined Q_OS_MAC
@@ -115,7 +115,7 @@ QString AppConfig::defaultValue(const QString &key)
 
     if(key == CONFIG::SHORTCUT_CAPTUREWINDOW)
 #ifdef Q_OS_LINUX
-        return QString();
+        return QStringLiteral("Meta+Alt+4");
 #elif defined Q_OS_WIN
         return QStringLiteral("Alt+4");
 #elif defined Q_OS_MAC
@@ -124,7 +124,7 @@ QString AppConfig::defaultValue(const QString &key)
 
     if(key == CONFIG::SHORTCUT_SCREENSHOT)
 #ifdef Q_OS_LINUX
-        return QString();
+        return QStringLiteral("Meta+Alt+3");
 #elif defined Q_OS_WIN
         return QStringLiteral("Alt+3");
 #elif defined Q_OS_MAC
@@ -133,7 +133,7 @@ QString AppConfig::defaultValue(const QString &key)
 
     if(key == CONFIG::COMMAND_SCREENSHOT)
 #ifdef Q_OS_LINUX
-        return QString();
+        return QFile::exists(gnomeSS) ? gnomeAreaCommand : QFile::exists(kdeSS) ? kdeAreaCommand : QFile::exists(xfceSS) ? xfceAreaCommand : QString();
 #elif defined Q_OS_WIN
         return QStringLiteral("C:\\Program Files\\IrfanView\\i_view64.exe /capture=4 convert=%file");
 #elif defined Q_OS_MAC
@@ -142,7 +142,7 @@ QString AppConfig::defaultValue(const QString &key)
 
     if(key == CONFIG::COMMAND_CAPTUREWINDOW)
 #ifdef Q_OS_LINUX
-        return QString();
+        return QFile::exists(gnomeSS) ? gnomeWindowCommand : QFile::exists(kdeSS) ? kdeWindowCommand : QFile::exists(xfceSS) ? xfceWindowCommand : QString();
 #elif defined Q_OS_WIN
         return QStringLiteral("C:\\Program Files\\IrfanView\\i_view64.exe /capture=0 convert=%file");
 #elif defined Q_OS_MAC

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -53,7 +53,8 @@ public:
     static QList<model::Tag> getLastUsedTags();
     /// Set the last used Tags
     static void setLastUsedTags(QList<model::Tag> lastTags);
-
+    /// Return the Default Value for a given key
+    static QString defaultValue(const QString &key = QString());
 signals:
     void operationChanged(QString operationSlug, QString operationName);
 

--- a/src/appconfig.h
+++ b/src/appconfig.h
@@ -76,6 +76,19 @@ private:
 #else
     inline static const QString _configFile = QStringLiteral("%1/ashirt/config.json").arg(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation));
 #endif
+#ifdef Q_OS_LINUX
+    inline static const auto gnomeSS = QStringLiteral("/usr/bin/gnome-screenshot");
+    inline static const auto gnomeWindowCommand = QStringLiteral("gnome-screenshot -w -f %file");
+    inline static const auto gnomeAreaCommand = QStringLiteral("gnome-screenshot -a -f %file");
+
+    inline static const auto kdeSS = QStringLiteral("/usr/bin/spectacle");
+    inline static const auto kdeWindowCommand = QStringLiteral("spectacle -a -bno %file");
+    inline static const auto kdeAreaCommand = QStringLiteral("spectacle -r -bno %file");
+
+    inline static const auto xfceSS = QStringLiteral("/usr/bin/xfce4-screenshooter");
+    inline static const auto xfceWindowCommand = QStringLiteral("xfce4-screenshooter -w -s %file");
+    inline static const auto xfceAreaCommand = QStringLiteral("xfce4-screenshooter -r -s %file");
+#endif
     inline static const auto _opSlugSetting = QStringLiteral("operation/slug");
     inline static const auto _opNameSetting = QStringLiteral("operation/name");
     inline static const auto _lastUsedTagsSetting = QStringLiteral("gather/tags");


### PR DESCRIPTION
 - Add a `defaultValue` method to AppConfig and set several defauts
 - Fixes #222  by providing defaults for a few common screen shot tools on linux