### PR TITLE
Fix key selector

### DIFF
--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -37,7 +37,7 @@ void AppConfig::setValue(const QString &key, const QString &value)
     if (AppConfig::value(key) == value)
         return;
 
-    if (value.isEmpty())
+    if (value.isNull())
         get()->appConfig->remove(key);
     else
         get()->appConfig->setValue(key, value);
@@ -104,32 +104,45 @@ QString AppConfig::defaultValue(const QString &key)
     if (key == CONFIG::APIURL)
         return QStringLiteral("http://localhost:8080");
 
-    if (key == CONFIG::SHORTCUT_CAPTURECLIPBOARD)
+    if (key == CONFIG::SHORTCUT_CAPTURECLIPBOARD) {
+          if(!get()->appSettings->value(key).isValid())
 #ifdef Q_OS_LINUX
-        return QStringLiteral("Meta+Alt+v");
+              return QStringLiteral("Meta+Alt+v");
 #elif defined Q_OS_WIN
-        return QStringLiteral("Alt+v");
+              return QStringLiteral("Alt+v");
 #elif defined Q_OS_MAC
-        return QStringLiteral("Option+v");
+              return QStringLiteral("Option+v");
 #endif
+          else
+              return QString();
+    }
 
-    if(key == CONFIG::SHORTCUT_CAPTUREWINDOW)
-#ifdef Q_OS_LINUX
-        return QStringLiteral("Meta+Alt+4");
-#elif defined Q_OS_WIN
-        return QStringLiteral("Alt+4");
-#elif defined Q_OS_MAC
-        return QStringLiteral("Option+shift+4");
-#endif
 
-    if(key == CONFIG::SHORTCUT_SCREENSHOT)
+    if(key == CONFIG::SHORTCUT_CAPTUREWINDOW) {
+          if(!get()->appSettings->value(key).isValid())
 #ifdef Q_OS_LINUX
-        return QStringLiteral("Meta+Alt+3");
+              return QStringLiteral("Meta+Alt+4");
 #elif defined Q_OS_WIN
-        return QStringLiteral("Alt+3");
+              return QStringLiteral("Alt+4");
 #elif defined Q_OS_MAC
-        return QStringLiteral("Option+shift+3");
+              return QStringLiteral("Option+shift+4");
 #endif
+          else
+              return QString();
+    }
+
+    if(key == CONFIG::SHORTCUT_SCREENSHOT) {
+        if(!get()->appSettings->value(key).isValid())
+#ifdef Q_OS_LINUX
+            return QStringLiteral("Meta+Alt+3");
+#elif defined Q_OS_WIN
+            return QStringLiteral("Alt+3");
+#elif defined Q_OS_MAC
+            return QStringLiteral("Option+shift+3");
+#endif
+        else
+            return QString();
+    }
 
     if(key == CONFIG::COMMAND_SCREENSHOT)
 #ifdef Q_OS_LINUX

--- a/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.cpp
+++ b/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.cpp
@@ -1,7 +1,7 @@
 #include "singlestrokekeysequenceedit.h"
 
 SingleStrokeKeySequenceEdit::SingleStrokeKeySequenceEdit(QWidget* parent) : QKeySequenceEdit(parent){
-  this->installEventFilter(this);
+  setClearButtonEnabled(true);
 }
 
 // Note: this may prevent editingFinished from firing
@@ -10,18 +10,5 @@ void SingleStrokeKeySequenceEdit::keyPressEvent(QKeyEvent * evt) {
 
   setKeySequence(keySequence()[0]);
   previousSequence = keySequence(); // update the saved sequence once one has been set
-}
-
-bool SingleStrokeKeySequenceEdit::eventFilter(QObject *object, QEvent *event) {
-  if (event->type() == QEvent::FocusIn) {
-    // save + remove the current sequence to provide the user with a prompt
-    previousSequence = keySequence();
-    clear();
-  }
-  if (event->type() == QEvent::FocusOut) {
-    // restore the current/saved sequence
-    setKeySequence(previousSequence);
-    Q_EMIT keySequenceChanged(previousSequence);
-  }
-  return QKeySequenceEdit::eventFilter(object, event);
+  Q_EMIT keySequenceChanged(previousSequence);
 }

--- a/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.h
+++ b/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.h
@@ -1,18 +1,16 @@
 #pragma once
 
-#include <QObject>
 #include <QKeySequenceEdit>
 #include <QKeyEvent>
 
 class SingleStrokeKeySequenceEdit : public QKeySequenceEdit
 {
+ Q_OBJECT
  public:
   SingleStrokeKeySequenceEdit(QWidget* parent=nullptr);
 
  protected:
   void keyPressEvent(QKeyEvent *evt) override;
-
-  bool eventFilter(QObject *object, QEvent *event) override;
 
  private:
   QKeySequence previousSequence;

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -49,9 +49,6 @@ void Settings::buildUi() {
   auto eviRepoBrowseButton = new QPushButton(tr("Browse"), this);
   connect(eviRepoBrowseButton, &QPushButton::clicked, this, &Settings::onBrowseClicked);
 
-  auto clearHotkeysButton = new QPushButton(tr("Clear Shortcuts"), this);
-  connect(clearHotkeysButton, &QPushButton::clicked, this, &Settings::onClearShortcutsClicked);
-
   auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Save | QDialogButtonBox::Cancel, this);
   connect(buttonBox, &QDialogButtonBox::accepted, this, &Settings::onSaveClicked);
   connect(buttonBox, &QDialogButtonBox::rejected, this, &Settings::onCancelClicked);
@@ -60,17 +57,17 @@ void Settings::buildUi() {
        +---------------+-------------+------------+-------------+
     0  | Evi Repo Lbl  |    [Evi Repo TB]         | browseBtn   |
        +---------------+-------------+------------+-------------+
-    1  | A. Key Label  |  [A. Key TB]                           |
+    1  | Host Label    |  [Host TB]                             |
        +---------------+-------------+------------+-------------+
-    2  | S. Key Label  |  [S. Key TB]                           |
+    2  | A. Key Label  |  [A. Key TB]                           |
        +---------------+-------------+------------+-------------+
-    3  | Host Label    |  [Host TB]                             |
+    3  | S. Key Label  |  [S. Key TB]                           |
        +---------------+-------------+------------+-------------+
     4  | Cap A Cmd Lbl | [CapACmdTB] | CapASh lbl | [CapASh TB] |
        +---------------+-------------+------------+-------------+
     5  | Cap W Cmd Lbl | [CapWCmdTB] | CapWSh lbl | [CapWSh TB] |
        +---------------+-------------+------------+-------------+
-    6  | CodeblkSh Lbl | [CodeblkSh TB] |  Clear Hotkey Btn     |
+    6  | CodeblkSh Lbl | [CodeblkSh TB]                         |
        +---------------+-------------+------------+-------------+
     7  | Test Conn Btn |  StatusLabel                           |
        +---------------+-------------+------------+-------------+
@@ -86,16 +83,16 @@ void Settings::buildUi() {
   gridLayout->addWidget(eviRepoBrowseButton, 0, 4);
 
   // row 1
-  gridLayout->addWidget(new QLabel(tr("Access Key"), this), 1, 0);
-  gridLayout->addWidget(accessKeyTextBox, 1, 1, 1, 4);
+  gridLayout->addWidget(new QLabel(tr("Server URL"), this), 1, 0);
+  gridLayout->addWidget(hostPathTextBox, 1, 1, 1, 4);
 
   // row 2
   gridLayout->addWidget(new QLabel(tr("Secret Key"), this), 2, 0);
   gridLayout->addWidget(secretKeyTextBox, 2, 1, 1, 4);
 
   // row 3
-  gridLayout->addWidget(new QLabel(tr("Host Path"), this), 3, 0);
-  gridLayout->addWidget(hostPathTextBox, 3, 1, 1, 4);
+  gridLayout->addWidget(new QLabel(tr("Access Key"), this), 3, 0);
+  gridLayout->addWidget(accessKeyTextBox, 3, 1, 1, 4);
 
   // row 4
   gridLayout->addWidget(new QLabel(tr("Capture Area Command"), this), 4, 0);
@@ -112,7 +109,6 @@ void Settings::buildUi() {
   // row 6 (reserved for codeblocks)
   gridLayout->addWidget(new QLabel(tr("Capture Clipboard Shortcut"), this), 6, 0);
   gridLayout->addWidget(captureClipboardShortcutTextBox, 6, 1);
-  gridLayout->addWidget(clearHotkeysButton, 6, 2, 1, 3, Qt::AlignRight);
 
   // row 7
   gridLayout->addWidget(testConnectionButton, 7, 0);
@@ -230,12 +226,6 @@ void Settings::onBrowseClicked() {
   if (filename != nullptr) {
     eviRepoTextBox->setText(QDir::toNativeSeparators(filename));
   }
-}
-
-void Settings::onClearShortcutsClicked() {
-  captureAreaShortcutTextBox->clear();
-  captureWindowShortcutTextBox->clear();
-  captureClipboardShortcutTextBox->clear();
 }
 
 void Settings::onTestConnectionClicked() {

--- a/src/forms/settings/settings.h
+++ b/src/forms/settings/settings.h
@@ -78,6 +78,5 @@ class Settings : public AShirtDialog {
   QKeySequenceEdit* captureClipboardShortcutTextBox = nullptr;
   LoadingButton* testConnectionButton = nullptr;
   QPushButton* eviRepoBrowseButton = nullptr;
-  QPushButton* clearHotkeysButton = nullptr;
   QErrorMessage* couldNotSaveSettingsMsg = nullptr;
 };


### PR DESCRIPTION
Changes to the SingleStrokeKeySequenceEditor
 - Emit `keySequenceChange` when its changed
 - Show the clear button for the control 
 - remove the event filter to clear the key on enter 

Changes to Settings Dialog
 - Update Settings Dialog to remove the clear settings button 
 - Update Settings Dialog to Use `Server URL` and place it above the api key lines

<img src="https://github.com/ashirt-ops/ashirt/assets/98421672/69161766-f77d-4f32-b5f8-c404b4155260" width="350">

Changes to AppConfig
 - Allow Shortcuts to be empty and default is never set.