### PR TITLE
Dbus Screen shot Test for linux

### DIFF
--- a/src/helpers/CMakeLists.txt
+++ b/src/helpers/CMakeLists.txt
@@ -44,11 +44,13 @@ target_link_libraries ( HELPERS
       Qt::GuiPrivate
 )
 
+if(UNIX)
+    find_package(Qt${QT_DEFAULT_MAJOR_VERSION} REQUIRED COMPONENTS DBus)
+    target_link_libraries(HELPERS PRIVATE Qt::DBus)
+endif()
+
 if(APPLE)
-    find_package(Qt${QT_DEFAULT_MAJOR_VERSION} REQUIRED COMPONENTS
-    DBus
-    )
-    target_link_libraries(HELPERS PRIVATE Qt::DBus ${CARBON_LIBRARY})
+    target_link_libraries(HELPERS PRIVATE ${CARBON_LIBRARY})
 elseif(UNIX AND NOT APPLE)
     target_link_libraries(HELPERS PRIVATE xcb xcb-keysyms pthread)
 elseif(WIN32)

--- a/src/helpers/screenshot.cpp
+++ b/src/helpers/screenshot.cpp
@@ -12,11 +12,40 @@
 #include "helpers/string_helpers.h"
 #include "helpers/system_helpers.h"
 
+#ifndef Q_OS_WIN
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusReply>
+#endif
+
 Screenshot::Screenshot(QObject *parent) : QObject(parent) {}
 
 void Screenshot::captureArea() { basicScreenshot(AppConfig::value(CONFIG::COMMAND_SCREENSHOT)); }
 
-void Screenshot::captureWindow() { basicScreenshot(AppConfig::value(CONFIG::COMMAND_CAPTUREWINDOW)); }
+void Screenshot::captureWindow() {
+  auto captureCommand = AppConfig::value(CONFIG::COMMAND_CAPTUREWINDOW);
+  if(!captureCommand.startsWith("DBUS")) {
+    basicScreenshot(AppConfig::value(CONFIG::COMMAND_CAPTUREWINDOW));
+    return;
+  }
+
+#ifndef Q_OS_WIN
+  // Attempt Dbus Capture
+  QDBusConnection bus = QDBusConnection::sessionBus();
+
+  QDBusInterface *i = new QDBusInterface("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop", "org.freedesktop.portal.Screenshot", bus, NULL);
+
+  QVariantMap options;
+  options["interactive"] = captureCommand.endsWith(QStringLiteral("INTERACTIVE")) ? true : false;
+
+  QDBusReply<QDBusObjectPath> repl = i->call("Screenshot", "", options);
+  if(repl.isValid()) {
+    bus.connect("", repl.value().path(), "org.freedesktop.portal.Request", "Response", this, SLOT(dbusScreenShot(uint, QVariantMap)));
+  } else {
+    qDebug() << "Something is wrong: " << repl.error();
+  }
+#endif
+}
 
 QString Screenshot::mkName()
 {
@@ -54,4 +83,21 @@ void Screenshot::basicScreenshot(QString cmdProto)
         Q_EMIT onScreenshotCaptured(trueName);
     });
     connect(ssTool, &QProcess::aboutToClose, ssTool, &QProcess::deleteLater);
+}
+
+void Screenshot::dbusScreenShot(uint responseCode, QVariantMap results)
+{
+    if(responseCode != 0) {
+        qDebug() << "Unable to take a screenshot";
+        return;
+    }
+    auto baseDir = SystemHelpers::pathToEvidence();
+    if(!QDir().mkpath(baseDir))
+        return;
+    auto newName = mkName();
+    auto tempFile = QDir::toNativeSeparators(m_fileTemplate.arg(QDir::tempPath(), newName));
+    auto oldFile = results["uri"].toString().mid(7);
+    QFile::copy(oldFile, tempFile);
+    QFile::remove(oldFile);
+    Q_EMIT onScreenshotCaptured(tempFile);
 }

--- a/src/helpers/screenshot.h
+++ b/src/helpers/screenshot.h
@@ -15,7 +15,6 @@ class Screenshot : public QObject {
   static QString mkName();
   static QString extension() { return QStringLiteral("png"); }
   static QString contentType() { return QStringLiteral("image"); }
-
  signals:
   void onScreenshotCaptured(QString filepath);
 
@@ -24,4 +23,7 @@ class Screenshot : public QObject {
   inline static const QString m_fileTemplate = QStringLiteral("%1/%2");
   inline static const QString m_doubleQuote = QStringLiteral("\"");
   inline static const QString m_space = QStringLiteral(" ");
+
+ private slots:
+  void dbusScreenShot(uint responseCode, QVariantMap results);
 };


### PR DESCRIPTION
Begin: #240 

Modify Capture Window to use dbus when the command is `DBUS` or `DBUS_INTERACTIVE`
 - Attempt to use the `xdg.freedesktop.portal.Desktop` to get screen shots. 
    1. To use DBus Capture you must set the `Capture Window Command` to `DBUS` only work on linux.
    2. To use Dbus with interactive flag set the `Capture Window Command` to `DBUS_INTERACTIVE` 

This only applies to linux and will be need if you run in a sand box and eventually for proper wayland support.

Another option that maybe more useful to use is to use spectacle in dbus mode , this would require the user install and setup spectacle for dbus mode 

Could try to use org.kde.KWin.ScreenShot2 also but that might only work on kde sesisons  (but does allow for the capture modes we use and want) 
