### PR TITLE
Use short ref name as the release tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,7 +194,7 @@ jobs:
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-       automatic_release_tag: ${{ github.ref }}
+       automatic_release_tag: ${{ github.ref_name }}
        prerelease: false
        title: ${{ github.ref }}
        files: ashirt-*/ashirt-*.*


### PR DESCRIPTION
The release workflow has two iterations of `refs/tags/` in the final target. This PR should resolve the tag name properly. 

https://github.com/ashirt-ops/ashirt/actions/runs/6399349076/job/17371787893#step:4:28