### PR TITLE
Several small adjustments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,11 +58,7 @@ else()
 endif()
      message(STATUS "VERSION: ${CMAKE_PROJECT_VERSION}")
 
-if(NOT QT_DEFAULT_MAJOR_VERSION)
-    set(QT_DEFAULT_MAJOR_VERSION 6 CACHE STRING "" FORCE)
-endif()
-
-find_package(Qt${QT_DEFAULT_MAJOR_VERSION} REQUIRED COMPONENTS
+find_package(Qt6 6.5.0 REQUIRED COMPONENTS
     Widgets
     Gui
     Network

--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -148,7 +148,7 @@ QString AppConfig::defaultValue(const QString &key)
 #ifdef Q_OS_LINUX
         return QFile::exists(gnomeSS) ? gnomeAreaCommand : QFile::exists(kdeSS) ? kdeAreaCommand : QFile::exists(xfceSS) ? xfceAreaCommand : QString();
 #elif defined Q_OS_WIN
-        return QStringLiteral("C:\\Program Files\\IrfanView\\i_view64.exe /capture=4 convert=%file");
+        return QStringLiteral("\"C:\\Program Files\\IrfanView\\i_view64.exe\" /capture=4 /convert=%file");
 #elif defined Q_OS_MAC
         return QStringLiteral("screencapture -s %file");
 #endif
@@ -157,7 +157,7 @@ QString AppConfig::defaultValue(const QString &key)
 #ifdef Q_OS_LINUX
         return QFile::exists(gnomeSS) ? gnomeWindowCommand : QFile::exists(kdeSS) ? kdeWindowCommand : QFile::exists(xfceSS) ? xfceWindowCommand : QString();
 #elif defined Q_OS_WIN
-        return QStringLiteral("C:\\Program Files\\IrfanView\\i_view64.exe /capture=0 convert=%file");
+        return QStringLiteral("\"C:\\Program Files\\IrfanView\\i_view64.exe\" /capture=0 /convert=%file");
 #elif defined Q_OS_MAC
         return QStringLiteral("screencapture -w %file");
 #endif

--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -106,42 +106,20 @@ QString AppConfig::defaultValue(const QString &key)
 
     if (key == CONFIG::SHORTCUT_CAPTURECLIPBOARD) {
           if(!get()->appSettings->value(key).isValid())
-#ifdef Q_OS_LINUX
               return QStringLiteral("Meta+Alt+v");
-#elif defined Q_OS_WIN
-              return QStringLiteral("Alt+v");
-#elif defined Q_OS_MAC
-              return QStringLiteral("Option+v");
-#endif
-          else
-              return QString();
+          return QString();
     }
-
 
     if(key == CONFIG::SHORTCUT_CAPTUREWINDOW) {
           if(!get()->appSettings->value(key).isValid())
-#ifdef Q_OS_LINUX
               return QStringLiteral("Meta+Alt+4");
-#elif defined Q_OS_WIN
-              return QStringLiteral("Alt+4");
-#elif defined Q_OS_MAC
-              return QStringLiteral("Option+shift+4");
-#endif
-          else
-              return QString();
+          return QString();
     }
 
     if(key == CONFIG::SHORTCUT_SCREENSHOT) {
         if(!get()->appSettings->value(key).isValid())
-#ifdef Q_OS_LINUX
             return QStringLiteral("Meta+Alt+3");
-#elif defined Q_OS_WIN
-            return QStringLiteral("Alt+3");
-#elif defined Q_OS_MAC
-            return QStringLiteral("Option+shift+3");
-#endif
-        else
-            return QString();
+        return QString();
     }
 
     if(key == CONFIG::COMMAND_SCREENSHOT)

--- a/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.cpp
+++ b/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.cpp
@@ -1,14 +1,10 @@
 #include "singlestrokekeysequenceedit.h"
+#include <QAbstractButton>
+#include <QLineEdit>
 
 SingleStrokeKeySequenceEdit::SingleStrokeKeySequenceEdit(QWidget* parent) : QKeySequenceEdit(parent){
   setClearButtonEnabled(true);
-}
-
-// Note: this may prevent editingFinished from firing
-void SingleStrokeKeySequenceEdit::keyPressEvent(QKeyEvent * evt) {
-  QKeySequenceEdit::keyPressEvent(evt);
-
-  setKeySequence(keySequence()[0]);
-  previousSequence = keySequence(); // update the saved sequence once one has been set
-  Q_EMIT keySequenceChanged(previousSequence);
+  setMaximumSequenceLength(1);
+  findChild<QLineEdit*>()->setReadOnly(true);
+  findChild<QLineEdit*>()->findChild<QAbstractButton*>()->setEnabled(true);
 }

--- a/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.h
+++ b/src/components/custom_keyseq_edit/singlestrokekeysequenceedit.h
@@ -1,17 +1,10 @@
 #pragma once
 
 #include <QKeySequenceEdit>
-#include <QKeyEvent>
 
 class SingleStrokeKeySequenceEdit : public QKeySequenceEdit
 {
  Q_OBJECT
  public:
   SingleStrokeKeySequenceEdit(QWidget* parent=nullptr);
-
- protected:
-  void keyPressEvent(QKeyEvent *evt) override;
-
- private:
-  QKeySequence previousSequence;
 };

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -17,10 +17,7 @@
 #include <QString>
 
 #include "appconfig.h"
-#include "dtos/checkConnection.h"
-#include "helpers/http_status.h"
 #include "helpers/netman.h"
-#include "helpers/cleanupreply.h"
 #include "hotkeymanager.h"
 #include "components/custom_keyseq_edit/singlestrokekeysequenceedit.h"
 #include "components/loading_button/loadingbutton.h"
@@ -232,7 +229,7 @@ void Settings::onTestConnectionClicked() {
   if (hostPathTextBox->text().isEmpty()
       || accessKeyTextBox->text().isEmpty()
       || secretKeyTextBox->text().isEmpty()) {
-    connStatusLabel->setText(tr("Please set Access Key, Secret key and Host Path first."));
+    connStatusLabel->setText(tr("Please set Access Key, Secret key and Server URL first."));
     return;
   }
   NetMan::testConnection(hostPathTextBox->text(), accessKeyTextBox->text(), secretKeyTextBox->text());

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -22,9 +22,8 @@
 #include "components/custom_keyseq_edit/singlestrokekeysequenceedit.h"
 #include "components/loading_button/loadingbutton.h"
 
-Settings::Settings(HotkeyManager *hotkeyManager, QWidget *parent)
+Settings::Settings(QWidget *parent)
     : AShirtDialog(parent, AShirtDialog::commonWindowFlags)
-    , hotkeyManager(hotkeyManager)
     , connStatusLabel(new QLabel(this))
     , eviRepoTextBox(new QLineEdit(this))
     , accessKeyTextBox(new QLineEdit(this))
@@ -163,7 +162,7 @@ void Settings::checkForDuplicateShortcuts(const QKeySequence& keySequence, QKeyS
 
 void Settings::showEvent(QShowEvent *evt) {
   QDialog::showEvent(evt);
-  hotkeyManager->disableHotkeys();
+  HotkeyManager::disableHotkeys();
   eviRepoTextBox->setFocus(); //setting focus to prevent retaining focus for macs
 
   // reset the form in case a user left junk in the text boxes and pressed "cancel"
@@ -184,12 +183,12 @@ void Settings::showEvent(QShowEvent *evt) {
 
 void Settings::closeEvent(QCloseEvent *event) {
   onSaveClicked();
-  hotkeyManager->enableHotkeys();
+  HotkeyManager::enableHotkeys();
   QDialog::closeEvent(event);
 }
 
 void Settings::onCancelClicked() {
-  hotkeyManager->enableHotkeys();
+  HotkeyManager::enableHotkeys();
   reject();
 }
 
@@ -211,7 +210,7 @@ void Settings::onSaveClicked() {
   AppConfig::setValue(CONFIG::SHORTCUT_CAPTUREWINDOW, captureWindowShortcutTextBox->keySequence().toString());
   AppConfig::setValue(CONFIG::SHORTCUT_CAPTURECLIPBOARD, captureClipboardShortcutTextBox->keySequence().toString());
 
-  hotkeyManager->updateHotkeys();
+  HotkeyManager::updateHotkeys();
   close();
 }
 

--- a/src/forms/settings/settings.h
+++ b/src/forms/settings/settings.h
@@ -26,10 +26,9 @@ class Settings : public AShirtDialog {
  public:
   /**
    * @brief Settings constructs the settings menu. UI will be built and wired.
-   * @param hotkeyManager a handle to the HotkeyManager, so hotkeys may be updated upon saving.
    * @param parent
    */
-  explicit Settings(HotkeyManager* hotkeyManager, QWidget* parent = nullptr);
+  explicit Settings(QWidget* parent = nullptr);
   ~Settings() = default;
 
  private:
@@ -61,9 +60,6 @@ class Settings : public AShirtDialog {
   void onBrowseClicked();
 
  private:
-  /// hotkeyManager is a (shared) reference to the HotkeyManager. Not to be deleted.
-  HotkeyManager* hotkeyManager;
-
   // UI components
   QLabel* connStatusLabel = nullptr;
 

--- a/src/helpers/hotkeys/hotkeymap.h
+++ b/src/helpers/hotkeys/hotkeymap.h
@@ -266,9 +266,9 @@ static QMap<uint32_t, uint32_t> KEY_MAP = {
 static QMap<uint32_t, uint32_t> MOD_MAP = {
     {Qt::Key_Shift, shiftKey},
     {Qt::Key_Alt, optionKey},
-    {Qt::Key_Control, controlKey},
+    {Qt::Key_Meta, controlKey},
     {Qt::Key_Option, optionKey},
-    {Qt::Key_Meta, cmdKey},
+    {Qt::Key_Control, cmdKey},
 };
 
 inline UKeyData QtKeyToMac(const UKeySequence &keySeq)

--- a/src/helpers/hotkeys/uglobalhotkeys.cpp
+++ b/src/helpers/hotkeys/uglobalhotkeys.cpp
@@ -107,7 +107,9 @@ bool UGlobalHotkeys::registerHotkey(const UKeySequence &keySeq, size_t id)
 void UGlobalHotkeys::unregisterHotkey(size_t id)
 {
 #if defined(Q_OS_WIN) || defined(Q_OS_LINUX)
-    Q_ASSERT(Registered.find(id) != Registered.end() && "Unregistered hotkey");
+    if(Registered.find(id) == Registered.end()) {
+        return;
+    }
 #endif
 #if defined(Q_OS_WIN)
     UnregisterHotKey(nullptr, id);

--- a/src/helpers/system_helpers.h
+++ b/src/helpers/system_helpers.h
@@ -1,7 +1,13 @@
 #pragma once
 
-#include <QString>
 #include <QDir>
+
+#ifdef Q_OS_WIN
+#include <QSettings>
+#else
+#include <QtGui/QGuiApplication>
+#include <QtGui/QPalette>
+#endif
 
 #include "appconfig.h"
 
@@ -21,5 +27,12 @@ class SystemHelpers {
     QDir().mkpath(root);
     return root;
   }
-
+  static bool isLightTheme() {
+#ifdef Q_OS_WIN
+    QSettings settings(QStringLiteral("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), QSettings::NativeFormat);
+    return settings.value(QStringLiteral("SystemUsesLightTheme")).toInt() == 1;
+#else
+    return qApp->palette().text().color().value() <= QColor(Qt::lightGray).value();
+#endif
+  }
 };

--- a/src/hotkeymanager.cpp
+++ b/src/hotkeymanager.cpp
@@ -4,51 +4,52 @@
 #include "hotkeymanager.h"
 #include "appconfig.h"
 
-HotkeyManager::HotkeyManager(QObject *parent)
-  : QObject (parent)
-  , hotkeyManager(new UGlobalHotkeys(this))
+HotkeyManager::HotkeyManager()
+  : m_hotkeyManager(new UGlobalHotkeys(this))
 {
-  connect(hotkeyManager, &UGlobalHotkeys::activated, this, &HotkeyManager::hotkeyTriggered);
+  connect(m_hotkeyManager, &UGlobalHotkeys::activated, this, &HotkeyManager::hotkeyTriggered);
 }
 
-HotkeyManager::~HotkeyManager() { delete hotkeyManager; }
+HotkeyManager::~HotkeyManager() { delete m_hotkeyManager; }
+
+void HotkeyManager::regKey(QString combo, GlobalHotkeyEvent evt)
+{
+  if (combo.isEmpty())
+    return;
+  registerKey(combo, evt);
+}
 
 void HotkeyManager::registerKey(const QString& binding, GlobalHotkeyEvent evt) {
-  hotkeyManager->registerHotkey(binding, size_t(evt));
+  get()->m_hotkeyManager->registerHotkey(binding, size_t(evt));
 }
 
 void HotkeyManager::unregisterKey(GlobalHotkeyEvent evt) {
-  hotkeyManager->unregisterHotkey(size_t(evt));
+  get()->m_hotkeyManager->unregisterHotkey(size_t(evt));
 }
 
 void HotkeyManager::hotkeyTriggered(size_t hotkeyIndex) {
   if (hotkeyIndex == ACTION_CAPTURE_AREA) {
-    Q_EMIT captureAreaHotkeyPressed();
+    Q_EMIT get()->captureAreaHotkeyPressed();
   }
   else if (hotkeyIndex == ACTION_CAPTURE_WINDOW) {
-    Q_EMIT captureWindowHotkeyPressed();
+    Q_EMIT get()->captureWindowHotkeyPressed();
   }
   else if (hotkeyIndex == ACTION_CAPTURE_CLIPBOARD) {
-    Q_EMIT clipboardHotkeyPressed();
+    Q_EMIT get()->clipboardHotkeyPressed();
   }
 }
 
 void HotkeyManager::disableHotkeys() {
-  hotkeyManager->unregisterAllHotkeys();
+  get()->m_hotkeyManager->unregisterAllHotkeys();
 }
 
 void HotkeyManager::enableHotkeys() {
-  updateHotkeys();
+  get()->updateHotkeys();
 }
 
 void HotkeyManager::updateHotkeys() {
-  hotkeyManager->unregisterAllHotkeys();
-  auto regKey = [this](QString combo, GlobalHotkeyEvent evt) {
-    if (!combo.isEmpty()) {
-      registerKey(combo, evt);
-    }
-  };
-  regKey(AppConfig::value(CONFIG::SHORTCUT_SCREENSHOT), ACTION_CAPTURE_AREA);
-  regKey(AppConfig::value(CONFIG::SHORTCUT_CAPTUREWINDOW), ACTION_CAPTURE_WINDOW);
-  regKey(AppConfig::value(CONFIG::SHORTCUT_CAPTURECLIPBOARD), ACTION_CAPTURE_CLIPBOARD);
+  get()->m_hotkeyManager->unregisterAllHotkeys();
+  get()->regKey(AppConfig::value(CONFIG::SHORTCUT_SCREENSHOT), ACTION_CAPTURE_AREA);
+  get()->regKey(AppConfig::value(CONFIG::SHORTCUT_CAPTUREWINDOW), ACTION_CAPTURE_WINDOW);
+  get()->regKey(AppConfig::value(CONFIG::SHORTCUT_CAPTURECLIPBOARD), ACTION_CAPTURE_CLIPBOARD);
 }

--- a/src/hotkeymanager.h
+++ b/src/hotkeymanager.h
@@ -13,12 +13,9 @@
  */
 class HotkeyManager : public QObject {
   Q_OBJECT
+  /// GlobalHotkeyEvent provides names for all possible application-global hotkeys
 
  public:
-  HotkeyManager(QObject *parent = nullptr);
-  ~HotkeyManager();
-
-  /// GlobalHotkeyEvent provides names for all possible application-global hotkeys
   enum GlobalHotkeyEvent {
     // Reserving 1 (UGlobalHotkey default)
     ACTION_CAPTURE_AREA = 2,
@@ -26,23 +23,26 @@ class HotkeyManager : public QObject {
     ACTION_CAPTURE_CLIPBOARD = 4,
   };
 
- public:
+  static HotkeyManager* get() {
+    static HotkeyManager m;
+    return &m;
+  }
   /**
    * @brief registerKey pairs a given key combination with a given event type.
    * @param binding A string representing the actual command (e.g. Alt+f1)
    * @param evt A GlobalHotkeyEvent specifying what should happen when a key is pressed.
    */
-  void registerKey(const QString& binding, GlobalHotkeyEvent evt);
+  static void registerKey(const QString& binding, GlobalHotkeyEvent evt);
   /// unregisterKey removes the handling specified for the given event. Safe to call even if
   /// no key has been registered.
-  void unregisterKey(GlobalHotkeyEvent evt);
+  static void unregisterKey(GlobalHotkeyEvent evt);
 
   /// disableHotkeys removes all of the keybindings.
-  void disableHotkeys();
+  static void disableHotkeys();
 
   /// enableHotkeys "restores" all of the currently set hotkeys. This acts as the counterpoint to
   /// disableHotkeys, but functionally is identical to updateHotKeys.
-  void enableHotkeys();
+  static void enableHotkeys();
 
  signals:
   /// clipboardHotkeyPressed signals when the ACTION_CAPTURE_CLIPBOARD event has been triggered.
@@ -55,13 +55,17 @@ class HotkeyManager : public QObject {
  public slots:
   /// updateHotkeys retrives AppConfig data to set known global hotkeys. Removes _all_ (Application)
   /// hotkeys when called.
-  void updateHotkeys();
+  static void updateHotkeys();
 
  private slots:
   /// hotkeyTriggered provides a slot for interacting with the underlying UGlobalHotkey manager.
-  void hotkeyTriggered(size_t hotkeyIndex);
+  static void hotkeyTriggered(size_t hotkeyIndex);
 
- private:
+ private:  
+  HotkeyManager();
+  ~HotkeyManager();
+  /// Interal Reg method used to filter Empty keys
+  void regKey(QString combo, GlobalHotkeyEvent evt);
   /// hotkeyManager is a reference to the raw hotkey manager, which a 3rd party manages.
-  UGlobalHotkeys* hotkeyManager;
+  UGlobalHotkeys* m_hotkeyManager = nullptr;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,10 +23,14 @@ int main(int argc, char* argv[])
     QCoreApplication::setApplicationName(QStringLiteral("ashirt"));
 #ifdef Q_OS_WIN
     QCoreApplication::setOrganizationName(QCoreApplication::applicationName());
+
 #endif
 
     QApplication app(argc, argv);
     app.setWindowIcon(getWindowIcon());
+#ifdef Q_OS_WIN
+    app.setStyle("fusion");
+#endif
 
     if(!QSystemTrayIcon::isSystemTrayAvailable()) {
         showMsgBox(QT_TRANSLATE_NOOP("main", "A System tray is required to interact with the application"));

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -30,9 +30,8 @@ TrayManager::TrayManager(QWidget * parent, DatabaseConnection* db)
     : QDialog(parent)
     , db(db)
     , screenshotTool(new Screenshot(this))
-    , hotkeyManager(new HotkeyManager(this))
     , updateCheckTimer(new QTimer(this))
-    , settingsWindow(new Settings(hotkeyManager, this))
+    , settingsWindow(new Settings(this))
     , evidenceManagerWindow(new EvidenceManager(this->db, this))
     , creditsWindow(new Credits(this))
     , importWindow(new PortingDialog(PortingDialog::Import, this->db, this))
@@ -43,7 +42,7 @@ TrayManager::TrayManager(QWidget * parent, DatabaseConnection* db)
     , allOperationActions(this)
 
 {
-  hotkeyManager->updateHotkeys();
+  HotkeyManager::updateHotkeys();
   updateCheckTimer->start(MS_IN_DAY); // every day
 
   buildUi();
@@ -106,11 +105,11 @@ void TrayManager::wireUi() {
           &TrayManager::onScreenshotCaptured);
 
   // connect to hotkey signals
-  connect(hotkeyManager, &HotkeyManager::clipboardHotkeyPressed, this,
+  connect(HotkeyManager::get(), &HotkeyManager::clipboardHotkeyPressed, this,
           &TrayManager::captureClipboardActionTriggered);
-  connect(hotkeyManager, &HotkeyManager::captureAreaHotkeyPressed, this,
+  connect(HotkeyManager::get(), &HotkeyManager::captureAreaHotkeyPressed, this,
           &TrayManager::captureAreaActionTriggered);
-  connect(hotkeyManager, &HotkeyManager::captureWindowHotkeyPressed, this,
+  connect(HotkeyManager::get(), &HotkeyManager::captureWindowHotkeyPressed, this,
           &TrayManager::captureWindowActionTriggered);
 
   // connect to network signals

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -25,11 +25,6 @@
 #include "helpers/system_helpers.h"
 #include "hotkeymanager.h"
 #include "models/codeblock.h"
-#include "porting/system_manifest.h"
-
-#if defined(Q_OS_WIN)
-#include <QSettings>
-#endif
 
 TrayManager::TrayManager(QWidget * parent, DatabaseConnection* db)
     : QDialog(parent)
@@ -316,18 +311,11 @@ void TrayManager::setTrayMessage(MessageType type, const QString& title, const Q
 
 QIcon TrayManager::getTrayIcon()
 {
-#if defined(Q_OS_LINUX)
-  QIcon icon = QIcon(palette().text().color().value() >= QColor(Qt::lightGray).value()
-                     ? QStringLiteral(":/icons/shirt-light.svg")
-                     : QStringLiteral(":/icons/shirt-dark.svg"));
-#elif defined(Q_OS_MACOS)
+#if defined(Q_OS_MACOS)
   QIcon icon = QIcon(QStringLiteral(":/icons/shirt-dark.svg"));
   icon.setIsMask(true);
-#elif defined(Q_OS_WIN)
-  QSettings settings(QStringLiteral("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), QSettings::NativeFormat);
-  QIcon icon = QIcon(settings.value(QStringLiteral("SystemUsesLightTheme")).toInt() == 0
-                     ? QStringLiteral(":/icons/shirt-light.svg")
-                     : QStringLiteral(":/icons/shirt-dark.svg"));
+#else
+  QIcon icon = SystemHelpers::isLightTheme() ?  QIcon(QStringLiteral(":/icons/shirt-dark.svg")) : QIcon(QStringLiteral(":/icons/shirt-light.svg"));
 #endif
   return icon;
 }

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -14,7 +14,6 @@
 #include "forms/porting/porting_dialog.h"
 #include "forms/settings/settings.h"
 #include "helpers/screenshot.h"
-#include "hotkeymanager.h"
 #include "forms/add_operation/createoperation.h"
 
 #ifndef QT_NO_SYSTEMTRAYICON
@@ -91,7 +90,6 @@ class TrayManager : public QDialog {
   inline static const int MS_IN_DAY = 86400000;
   QString _recordErrorTitle = tr("Unable to Record Evidence");
   DatabaseConnection *db = nullptr;
-  HotkeyManager *hotkeyManager = nullptr;
   Screenshot *screenshotTool = nullptr;
   QTimer *updateCheckTimer = nullptr;
   MessageType currentTrayMessage = NO_ACTION;


### PR DESCRIPTION
 - Make `HotKeyManager` a singleton
 - Fix the Windows default commands for area and window capture
 - New bool SystemHelpers::isLightMode() method
 - Use `fusion` style on windows 
 - Further simplify the `SingleStrokeKeySequenceEdit`
 - We are using new features from Qt 6.5 so we now Require Qt 6.5+ to build
 - Unify all default shortcuts to `Meta+Alt+<key>` this is `Command+Option+<key>` on Mac os
 - Fix on Mac os `Command` and `Control` were mapped backwards. `Meta` is the `Control` key on Mac and `Ctrl` is the `Command` Key
