### PR TITLE
Removal of Verizon and Yahoo

### DIFF
--- a/Code-of-Conduct.md
+++ b/Code-of-Conduct.md
@@ -1,16 +1,14 @@
-# Verizon Media Open Source Code of Conduct
+# ASHIRT Code of Conduct
 
 ## Summary
 This Code of Conduct is our way to encourage good behavior and discourage bad behavior in our open source projects. We invite participation from many people to bring different perspectives to our projects. We will do our part to foster a welcoming and professional environment free of harassment. We expect participants to communicate professionally and thoughtfully during their involvement with this project. 
-
-Participants may lose their good standing by engaging in misconduct. For example: insulting, threatening, or conveying unwelcome sexual content. We ask participants who observe conduct issues to report the incident directly to the project's Response Team at opensource-conduct@verizonmedia.com. Verizon Media will assign a respondent to address the issue. We may remove harassers from this project. 
 
 This code does not replace the terms of service or acceptable use policies of the websites used to support this project. We acknowledge that participants may be subject to additional conduct terms based on their employment which may govern their online expressions.
 
 ## Details
 This Code of Conduct makes our expectations of participants in this community explicit.
 * We forbid harassment and abusive speech within this community.
-* We request participants to report misconduct to the project’s Response Team.
+* We request participants to report misconduct to the project’s moderation team on discord.
 * We urge participants to refrain from using discussion forums to play out a fight.
 
 ### Expected Behaviors
@@ -25,7 +23,7 @@ We expect participants in this community to conduct themselves professionally. S
 * **Leave with class.** When you wish to resign from participating in this project for any reason, you are free to fork the code and create a competitive project. Open Source explicitly allows this. Your exit should not be dramatic or bitter. 
 
 ### Unacceptable Behaviors
-Participants remain in good standing when they do not engage in misconduct or harassment (some examples follow). We do not list all forms of harassment, nor imply some forms of harassment are not worthy of action. Any participant who *feels* harassed or *observes* harassment, should report the incident to the Response Team. 
+Participants remain in good standing when they do not engage in misconduct or harassment (some examples follow). We do not list all forms of harassment, nor imply some forms of harassment are not worthy of action. Any participant who *feels* harassed or *observes* harassment, should report the incident to the moderation team.
 * **Don't be a bigot.** Calling out project members by their identity or background in a negative or insulting manner. This includes, but is not limited to, slurs or insinuations related to protected or suspect classes e.g. race, color, citizenship, national origin, political belief, religion, sexual orientation, gender identity and expression, age, size, culture, ethnicity, genetic features, language, profession, national minority status, mental or physical ability.
 * **Don't insult.** Insulting remarks about a person’s lifestyle practices.
 * **Don't dox.** Revealing private information about other participants without explicit permission.
@@ -35,18 +33,10 @@ Participants remain in good standing when they do not engage in misconduct or ha
 * **Don't disrupt.** Sustained disruptions in a discussion.
 
 ### Reporting Issues
-If you experience or witness misconduct, or have any other concerns about the conduct of members of this project, please report it by contacting our Response Team at opensource-conduct@verizonmedia.com who will handle your report with discretion. Your report should include:
+If you experience or witness misconduct, or have any other concerns about the conduct of members of this project, please report it by contacting a moderator on discord who will handle your report with discretion. Your report should include:
 * Your preferred contact information. We cannot process anonymous reports.
 * Names (real or usernames) of those involved in the incident.
 * Your account of what occurred, and if the incident is ongoing. Please provide links to or transcripts of the publicly available records (e.g. a mailing list archive or a public IRC logger), so that we can review it.
 * Any additional information that may be helpful to achieve resolution.
 
-After filing a report, a representative will contact you directly to review the incident and ask additional questions. If a member of the Verizon Media Response Team is named in an incident report, that member will be recused from handling your incident. If the complaint originates from a member of the Response Team, it will be addressed by a different member of the Response Team. We will consider reports to be confidential for the purpose of protecting victims of abuse. 
-
-### Scope
-Verizon Media will assign a Response Team member with admin rights on the project and legal rights on the project copyright. The Response Team is empowered to restrict some privileges to the project as needed. Since this project is governed by an open source license, any participant may fork the code under the terms of the project license. The Response Team’s goal is to preserve the project if possible, and will restrict or remove participation from those who disrupt the project. 
-
-This code does not replace the terms of service or acceptable use policies that are provided by the websites used to support this community. Nor does this code apply to communications or actions that take place outside of the context of this community. Many participants in this project are also subject to codes of conduct based on their employment. This code is a social-contract that informs participants of our social expectations. It is not a terms of service or legal contract.
-
-## License and Acknowledgment. 
-This text is shared under the [CC-BY-4.0 license](https://creativecommons.org/licenses/by/4.0/). This code is based on a study conducted by the [TODO Group](https://todogroup.org/) of many codes used in the open source community. If you have feedback about this code, contact our Response Team at the address listed above. 
+After filing a report, a representative will contact you directly to review the incident and ask additional questions. If a member of the moderation team is named in an incident report, that member will be recused from handling your incident. If the complaint originates from a member of the moderation team, it will be addressed by a different member of the moderation team. We will consider reports to be confidential for the purpose of protecting victims of abuse.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2020 Verizon Media
+Copyright 2020
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/src/components/evidence_editor/evidenceeditor.cpp
+++ b/src/components/evidence_editor/evidenceeditor.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "evidenceeditor.h"
 
 #include <QFile>

--- a/src/components/evidence_editor/evidenceeditor.h
+++ b/src/components/evidence_editor/evidenceeditor.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QWidget>

--- a/src/components/loading_button/loadingbutton.cpp
+++ b/src/components/loading_button/loadingbutton.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "loadingbutton.h"
 
 #include <QResizeEvent>

--- a/src/components/loading_button/loadingbutton.h
+++ b/src/components/loading_button/loadingbutton.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QPushButton>

--- a/src/db/databaseconnection.cpp
+++ b/src/db/databaseconnection.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "databaseconnection.h"
 
 #include <QDir>

--- a/src/db/databaseconnection.h
+++ b/src/db/databaseconnection.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QSqlDatabase>

--- a/src/dtos/operation.h
+++ b/src/dtos/operation.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QVariant>

--- a/src/dtos/tag.h
+++ b/src/dtos/tag.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QVariant>

--- a/src/forms/credits/credits.cpp
+++ b/src/forms/credits/credits.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "credits.h"
 
 #include <QDateTime>

--- a/src/forms/credits/credits.h
+++ b/src/forms/credits/credits.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include "ashirtdialog/ashirtdialog.h"
@@ -43,7 +40,7 @@ class Credits : public AShirtDialog {
   inline static const auto preambleMarkdown
       = QStringLiteral("Version: %1 \n\n"
                    "Commit Hash: %2\n\n"
-                   "Copyright %3, Verizon Media\n\n"
+                   "Copyright %3\n\n"
                    "Licensed under the terms of %4\n\n"
                    "A short user guide can be found %5\n\n"
                    "Report issues %6\n\n")

--- a/src/forms/evidence/evidencemanager.cpp
+++ b/src/forms/evidence/evidencemanager.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "evidencemanager.h"
 
 #include <QApplication>

--- a/src/forms/evidence/evidencemanager.h
+++ b/src/forms/evidence/evidencemanager.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include "ashirtdialog/ashirtdialog.h"

--- a/src/forms/evidence_filter/evidencefilter.cpp
+++ b/src/forms/evidence_filter/evidencefilter.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "evidencefilter.h"
 
 QString EvidenceFilters::standardizeFilterKey(QString key) {

--- a/src/forms/evidence_filter/evidencefilter.h
+++ b/src/forms/evidence_filter/evidencefilter.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QDate>

--- a/src/forms/evidence_filter/evidencefilterform.cpp
+++ b/src/forms/evidence_filter/evidencefilterform.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "evidencefilterform.h"
 
 #include <QComboBox>

--- a/src/forms/evidence_filter/evidencefilterform.h
+++ b/src/forms/evidence_filter/evidencefilterform.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include "ashirtdialog/ashirtdialog.h"

--- a/src/forms/getinfo/getinfo.cpp
+++ b/src/forms/getinfo/getinfo.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "getinfo.h"
 
 #include <QGridLayout>

--- a/src/forms/getinfo/getinfo.h
+++ b/src/forms/getinfo/getinfo.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include "ashirtdialog/ashirtdialog.h"

--- a/src/forms/settings/settings.cpp
+++ b/src/forms/settings/settings.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "settings.h"
 
 #include <QDateTime>

--- a/src/forms/settings/settings.h
+++ b/src/forms/settings/settings.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include "ashirtdialog/ashirtdialog.h"

--- a/src/helpers/jsonhelpers.h
+++ b/src/helpers/jsonhelpers.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QJsonArray>

--- a/src/helpers/netman.h
+++ b/src/helpers/netman.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QMessageAuthenticationCode>

--- a/src/helpers/screenshot.cpp
+++ b/src/helpers/screenshot.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "screenshot.h"
 
 #include <QDir>

--- a/src/helpers/screenshot.h
+++ b/src/helpers/screenshot.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QObject>

--- a/src/hotkeymanager.cpp
+++ b/src/hotkeymanager.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "hotkeymanager.h"
 #include "appconfig.h"
 

--- a/src/hotkeymanager.h
+++ b/src/hotkeymanager.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QObject>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include <QApplication>
 #include <QMessageBox>
 #include <QMetaType>

--- a/src/models/evidence.h
+++ b/src/models/evidence.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QDateTime>

--- a/src/models/tag.h
+++ b/src/models/tag.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QDataStream>

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #include "traymanager.h"
 
 #ifndef QT_NO_SYSTEMTRAYICON

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -1,6 +1,3 @@
-// Copyright 2020, Verizon Media
-// Licensed under the terms of MIT. See LICENSE file in project root for terms.
-
 #pragma once
 
 #include <QActionGroup>


### PR DESCRIPTION
This PR removes language related to Verizon Media or Yahoo. Per-file copyright and license information is removed in favor of the project LICENSE file.