### PR TITLE
Update max length for access key

### DIFF
--- a/src/forms/firstRunWizard/apikeyspage.cpp
+++ b/src/forms/firstRunWizard/apikeyspage.cpp
@@ -71,7 +71,7 @@ ApiKeysPage::ApiKeysPage(QWidget *parent)
   _lblAKey->setText(tr("Access Key"));
 
   accessKeyLine = new QLineEdit(this);
-  accessKeyLine->setMaxLength(24);
+  accessKeyLine->setMaxLength(27);
   accessKeyLine->setTextMargins(3,0,3,0);
   accessKeyLine->setMaximumWidth(fontMetrics().averageCharWidth() * 27);
   registerField("host.accessKey*", accessKeyLine);


### PR DESCRIPTION
This caused the client to break after a recent change to prefix access keys with "AS-". Likely this was causing the access key to be truncated.

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/ashirt/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/ashirt/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.