### PR TITLE
Update macOS notarization to use notarytool

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -155,11 +155,12 @@ jobs:
                 -i ../deploy/hicolor/128x128/apps/ashirt.png \
                 --plugin=qt
         elif [[ "$RUNNER_OS" == "macOS" && "${{ env.signMacRelease }}" == "true" ]]; then
-            brew tap mitchellh/gon
-            brew install mitchellh/gon/gon jq
-            export ID=${{ env.name }}.dmg
-            echo "${{ secrets.GON_CONF }}" | base64 -D -i - | jq '.notarize[0].path = env.ID' > notarize.json
-            gon notarize.json
+            # Prepare application for notarization
+            xcrun notarytool store-credentials "AC_PASSWORD" --apple-id ${{ secrets.APPLE_ID }} --team-id ${{ secrets.TEAM_ID }} --password ${{ secrets.APP_SPECIFIC_PASSWORD }}
+            # Notarize the application
+            xcrun notarytool submit ${{env.name}}.dmg --keychain-profile "AC_PASSWORD" --wait
+            # Staple the ticket to the application
+            xcrun stapler staple ${{env.name}}.dmg
         elif [[ "$RUNNER_OS" == "Windows" && "${{ env.signWinRelease }}" == "true" ]]; then
             signtool sign -f certificate\\certificate.pfx -fd certHash -p '${{ secrets.WIN_CERT_PASS }}' -t http://timestamp.digicert.com ${{env.name}}.exe
         fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ if(APPLE)
             TARGET ashirt POST_BUILD
             COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks
             COMMAND install ${HOMEBREW_CELLAR}/brotli/1.1.0/lib/libbrotlicommon.1.1.0.dylib ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks/libbrotlicommon.1.dylib
+            COMMAND codesign --remove-signature ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks/libbrotlicommon.1.dylib
             COMMAND codesign -v --timestamp --sign ${NOTARIZE_AS} ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app/Contents/Frameworks/libbrotlicommon.1.dylib
             COMMAND ${PLATFORMDEPLOYQT} ${CMAKE_CURRENT_BINARY_DIR}/ashirt.app -sign-for-notarization=${NOTARIZE_AS}
         )


### PR DESCRIPTION
Related to #251

Updates the CI pipeline to use `notarytool` for macOS notarization and removes references to `Gon`.

- Removes the section that installs and uses `Gon` for macOS notarization in the `.github/workflows/ci.yaml` file.
- Adds steps to install `notarytool`, prepare the application for notarization, submit it for notarization, and staple the notarization ticket to the application in the macOS build steps.
- Utilizes environment variables for Apple ID, Team ID, and an app-specific password to authenticate with Apple's notarization service.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ashirt-ops/ashirt/issues/251?shareId=63edb3e5-eb8e-4201-b739-f42cff47bb04).