### PR TITLE
Update Developer Readme with Correct Build Instructions

### DIFF
--- a/Readme_Developer.md
+++ b/Readme_Developer.md
@@ -2,13 +2,15 @@
 
 ## Building and Build Requirements
 
-This application is built off of Qt 5, and utilizes's Qt's networking and Sql featuresets. To build, your specific system may need the following:
+This application is built off of Qt 6.5+, and utilizes's Qt's networking and Sql featuresets. To build, your specific system may need the following:
 
-1. Qt 5, `qmake`, and possibly Qt Creator IDE.
+1. Qt 6.5+, `qmake`, and possibly Qt Creator IDE.
    1. Binaries located [here](https://www.qt.io/download-qt-installer?hsCtaTracking=99d9dd4f-5681-48d2-b096-470725510d34%7C074ddad0-fdef-4e53-8aa8-5e8a876d6ab4). You may need to alter which downloader you install.
 2. SQLite C driver (for SQLite version 3)
    1. On Fedora, this can be installed with `yum install sqlite-devel`
    2. On Arch systems, this can be installed with `pacman -S sqlite-doc`
+3. For Ubuntu/Debian systems, you may need to install additional dependencies:
+   1. `apt install sqlite3 libxcb-keysyms1-dev`
 
 ## Versioning and Update Checks
 
@@ -18,7 +20,7 @@ This code is found by tracing its usage from it's initial request. Currently, th
 
 ### Adding Versioning
 
-This application attempts to add versioning data when building. This is accomplished by leveraging qmake's ability to add in preprocessor macros. This can be seen by looking in the `ashirt.pro` file, specifically looking for the `DEFINES` definition/updates, and tracing those additions back. For this project in particular a few fields are defined:
+This application attempts to add versioning data when building. This is accomplished by leveraging qmake's ability to add in preprocessor macros. This can be seen by looking in the `CMakeLists.txt` file, specifically looking for the `DEFINES` definition/updates, and tracing those additions back. For this project in particular a few fields are defined:
 
 | Field                 | default Value      | Meaning                                                                                                                                                                                  |
 | --------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -26,7 +28,7 @@ This application attempts to add versioning data when building. This is accompli
 | `COMMIT_HASH`         | Unknown            | Contains the commit hash used when building this release. Displayed to the user                                                                                                          |
 | `SOURCE_CONTROL_REPO` | (empty string)     | Contains the path to source control, relative to source control's domain. As this relates to github, this should be of the form `owner/repo`, or, for this project `theparanoids/ashirt` |
 
-Currently, these fields are populated by looking at environment variables that GitHub Actions provides. If forking, these environment variables can be replaced by looking for `$$getenv(GITHUB_` prefixes in the `ashirt.pro` file
+Currently, these fields are populated by looking at environment variables that GitHub Actions provides. If forking, these environment variables can be replaced by looking for `$$getenv(GITHUB_` prefixes in the `CMakeLists.txt` file
 
 ## Adding a db migration
 

--- a/Readme_Developer.md
+++ b/Readme_Developer.md
@@ -4,7 +4,7 @@
 
 This application is built off of Qt 6.5+, and utilizes's Qt's networking and Sql featuresets. To build, your specific system may need the following:
 
-1. Qt 6.5+, `qmake`, and possibly Qt Creator IDE.
+1. Qt 6.5+, `cmake`, and possibly Qt Creator IDE.
    1. Binaries located [here](https://www.qt.io/download-qt-installer?hsCtaTracking=99d9dd4f-5681-48d2-b096-470725510d34%7C074ddad0-fdef-4e53-8aa8-5e8a876d6ab4). You may need to alter which downloader you install.
 2. SQLite C driver (for SQLite version 3)
    1. On Fedora, this can be installed with `yum install sqlite-devel`
@@ -20,7 +20,7 @@ This code is found by tracing its usage from it's initial request. Currently, th
 
 ### Adding Versioning
 
-This application attempts to add versioning data when building. This is accomplished by leveraging qmake's ability to add in preprocessor macros. This can be seen by looking in the `CMakeLists.txt` file, specifically looking for the `DEFINES` definition/updates, and tracing those additions back. For this project in particular a few fields are defined:
+This application attempts to add versioning data when building. This is accomplished by leveraging cmake's ability to add in preprocessor macros. This can be seen by looking in the `CMakeLists.txt` file, specifically looking for the `DEFINES` definition/updates, and tracing those additions back. For this project in particular a few fields are defined:
 
 | Field                 | default Value      | Meaning                                                                                                                                                                                  |
 | --------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Related to #243

Updates the `Readme_Developer.md` to reflect the current build requirements and instructions.

- **Updates Qt version requirement**: Changes the required Qt version from 5 to 6.5+, aligning with the project's current dependencies.
- **Adds installation commands for Ubuntu/Debian**: Introduces specific commands (`apt install sqlite3 libxcb-keysyms1-dev`) for installing necessary dependencies on Ubuntu/Debian systems.
- **Corrects build file reference**: Replaces the outdated reference to `ashirt.pro` with the current `CMakeLists.txt` file used for building the project.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ashirt-ops/ashirt/issues/243?shareId=e79cec7b-8369-4400-b39b-75d2fc1d9ff7).