### PR TITLE
fix: logic bug in importConfig function

### DIFF
--- a/src/appconfig.cpp
+++ b/src/appconfig.cpp
@@ -61,7 +61,7 @@ void AppConfig::importConfig(const QString &fileName)
         return;
     QSettings oldConfig(fileName, JSON);
     for (const auto &key : oldConfig.allKeys()) {
-        if (key != CONFIG::ACCESSKEY || key != CONFIG::SECRETKEY || key != CONFIG::APIURL)
+        if (key != CONFIG::ACCESSKEY && key != CONFIG::SECRETKEY && key != CONFIG::APIURL)
             AppConfig::setValue(key, QString());
         else
             AppConfig::setValue(key, oldConfig.value(key).toString());


### PR DESCRIPTION
The importConfig function had inverted boolean logic that caused ALL configuration keys to be cleared instead of imported.

The condition used OR (||) instead of AND (&&), which meant it was always true for any key:
- If key == ACCESSKEY: (false || true || true) = true → cleared ✗
- If key == SECRETKEY: (true || false || true) = true → cleared ✗
- If key == APIURL: (true || true || false) = true → cleared ✗
- If key == other: (true || true || true) = true → cleared ✗

This completely broke the import functionality - users could not migrate configurations between machines.

Fix: Changed OR (||) to AND (&&) so the condition is only true for non-credential keys, allowing credentials to be properly imported.

Impact: Users can now successfully import configurations including API keys, secret keys, and API URLs.

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/ashirt/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/ashirt/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.