### PR TITLE
chore: Add validation for operation slugs to prevent path traversal

### DIFF
--- a/src/helpers/string_helpers.h
+++ b/src/helpers/string_helpers.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QRandomGenerator>
+#include <QRegularExpression>
 #include <QString>
 
 class StringHelpers {
@@ -16,6 +17,34 @@ class StringHelpers {
     for(int i = 0; i < numberOfChars; i++)
         rString.append(_chars.at(QRandomGenerator::global()->bounded(_chars.length())));
     return rString;
+  }
+
+  /**
+   * @brief isValidOperationSlug Validates an operation slug for safe use in file paths
+   * Operation slugs are used in constructing file paths, so they must not contain
+   * path traversal sequences or other filesystem-unsafe characters.
+   * @param slug The operation slug to validate
+   * @return true if slug is safe to use in file paths, false otherwise
+   */
+  static bool isValidOperationSlug(const QString& slug) {
+    if (slug.isEmpty() || slug.length() > 128) {
+      return false;
+    }
+    
+    // Only allow alphanumeric, hyphen, underscore
+    QRegularExpression validPattern(QStringLiteral("^[a-zA-Z0-9_-]+$"));
+    if (!validPattern.match(slug).hasMatch()) {
+      return false;
+    }
+    
+    // Explicitly reject path traversal patterns
+    if (slug.contains(QStringLiteral("..")) || 
+        slug.contains(QStringLiteral("/")) || 
+        slug.contains(QStringLiteral("\\"))) {
+      return false;
+    }
+    
+    return true;
   }
 
   private:

--- a/src/helpers/system_helpers.h
+++ b/src/helpers/system_helpers.h
@@ -10,6 +10,7 @@
 #endif
 
 #include "appconfig.h"
+#include "string_helpers.h"
 
 class SystemHelpers {
 
@@ -21,7 +22,12 @@ class SystemHelpers {
     auto op = AppConfig::operationSlug();
     auto root = QStringLiteral("%1/").arg(AppConfig::value(CONFIG::EVIDENCEREPO));
     if (!op.isEmpty()) {
-      root.append(QStringLiteral("%1/").arg(op));
+      if (!StringHelpers::isValidOperationSlug(op)) {
+        qWarning() << "Invalid operation slug detected, ignoring:" << op;
+      }
+      else {
+        root.append(QStringLiteral("%1/").arg(op));
+      }
     }
 
     QDir().mkpath(root);

--- a/src/porting/system_manifest.cpp
+++ b/src/porting/system_manifest.cpp
@@ -34,6 +34,13 @@ void SystemManifest::migrateDb(DatabaseConnection* systemDb)
             auto importRecord = importDb.getEvidenceDetails(item.evidenceID);
             if (importRecord.id == 0)
                 continue; // in the odd situation that evidence doesn't match up, just skip it
+            
+            // Validate operation slug to prevent path traversal attacks
+            if (!StringHelpers::isValidOperationSlug(importRecord.operationSlug)) {
+                qWarning() << "Skipping evidence with invalid operation slug:" << importRecord.operationSlug;
+                continue;
+            }
+            
             QString newEvidencePath = QStringLiteral("%1/%2/%3")
                     .arg(AppConfig::value(CONFIG::EVIDENCEREPO)
                          , importRecord.operationSlug


### PR DESCRIPTION
Operation slugs are provided by the ASHIRT server or imported from export files and used to construct filesystem paths. Without validation, malicious slugs containing path traversal sequences (../, etc.) could cause evidence files to be written outside the intended evidence directory.

Changes:
1. Added StringHelpers::isValidOperationSlug() function
   - Validates slug format (alphanumeric, hyphen, underscore only)
   - Rejects empty or overly long slugs (>128 chars)
   - Explicitly blocks path traversal patterns (.., /, \)

2. Applied validation in SystemHelpers::pathToEvidence()
   - Validates slugs from server at runtime
   - Logs warning and falls back to root evidence directory
   - Prevents compromised server from writing to arbitrary paths

3. Applied validation in SystemManifest::migrateDb()
   - Validates slugs from imported databases
   - Skips evidence with invalid slugs during import
   - Prevents malicious export files from exploiting path traversal

Attack scenarios prevented:
- Compromised ASHIRT server cannot write evidence to arbitrary locations
- Malicious export files cannot perform path traversal during import
- Social engineering attacks via crafted export files are mitigated

Impact:
- Defense in depth against server compromise
- Protection against malicious import files
- Maintains backward compatibility (valid slugs unchanged)

Security: Fixes MEDIUM severity path traversal vulnerability

<!--
Thank you for your interest in and contributing to ASHIRT! There
are a few simple things to check before submitting your pull request
that can help with the review process. We only seek to accept code that you are authorized to contribute to the project. This pull request template is included on our projects so that your contributions are made with the following confirmation: I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
-->

- Please review our [contributing guidelines](https://github.com/theparanoids/ashirt/blob/master/Contributing.md)
- Please review our [Code of Conduct](https://github.com/theparanoids/ashirt/blob/master/Code-of-Conduct.md)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.