### PR TITLE
Update to Qt 6.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 permissions:
   contents: read
 env:
-    QT_VERSION: 6.10.2
+    QT_VERSION: 6.11.1
 jobs:
   # This is a super hacky way to get this into a place that can actually be
   # used by downstream jobs because YAML values don't allow shell

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ else()
 endif()
      message(STATUS "VERSION: ${CMAKE_PROJECT_VERSION}")
 
-find_package(Qt6 6.10.0 REQUIRED COMPONENTS
+find_package(Qt6 6.11.0 REQUIRED COMPONENTS
     Widgets
     Gui
     Network

--- a/Readme_Developer.md
+++ b/Readme_Developer.md
@@ -2,9 +2,9 @@
 
 ## Building and Build Requirements
 
-This application is built off of Qt 6.10+, and utilizes's Qt's networking and Sql featuresets. To build, your specific system may need the following:
+This application is built off of Qt 6.11+, and utilizes's Qt's networking and Sql featuresets. To build, your specific system may need the following:
 
-1. Qt 6.10+, `cmake`, and possibly Qt Creator IDE.
+1. Qt 6.11+, `cmake`, and possibly Qt Creator IDE.
    1. Binaries located [here](https://www.qt.io/download-qt-installer?hsCtaTracking=99d9dd4f-5681-48d2-b096-470725510d34%7C074ddad0-fdef-4e53-8aa8-5e8a876d6ab4). You may need to alter which downloader you install.
 2. SQLite C driver (for SQLite version 3)
    1. On Fedora, this can be installed with `yum install sqlite-devel`


### PR DESCRIPTION
Updates the project's Qt dependency from 6.10 to 6.11.

## Changes
- `CMakeLists.txt` — bump `find_package` minimum from `Qt6 6.10.0` to `6.11.0`
- `.github/workflows/ci.yaml` — bump CI `QT_VERSION` from `6.10.2` to `6.11.1` (latest 6.11 patch release)
- `Readme_Developer.md` — update build requirement references from Qt 6.10+ to 6.11+