### PR TITLE
Add missing break in OPEN_PATH case of onTrayMessageClicked

### DIFF
--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -347,6 +347,7 @@ void TrayManager::onTrayMessageClicked() {
       break;
     case OPEN_PATH:
       QDesktopServices::openUrl(openServicesPath);
+      break;
     case NO_ACTION:
     default:
       break;


### PR DESCRIPTION
## Summary

Adds the missing `break;` after the `OPEN_PATH` case in `TrayManager::onTrayMessageClicked()` (`src/traymanager.cpp`), so control no longer falls through into the `NO_ACTION`/`default` arm.

```cpp
case OPEN_PATH:
  QDesktopServices::openUrl(openServicesPath);
  break;
case NO_ACTION:
default:
  break;
```

Harmless today (the `NO_ACTION`/`default` arm only contains `break`), but it would silently run any future statement added to the `NO_ACTION` case when a user clicks an `OPEN_PATH` ("Export Complete") tray notification.

Fixes #274