### PR TITLE
Use windows-2025-vs2026 runner for Windows build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
           }
         - {
             name: "Windows", WIN_ARCH: "x64"
-            , os: windows-2022
+            , os: windows-2025-vs2026
             , QT_INST_DIR: "C:/", QT_ARCH: win64_msvc2022_64
             , extraCMakeConfig: "-G Ninja"
             , buildTarget: "--target package"


### PR DESCRIPTION
## Summary

Moves the Windows CI build from the `windows-2022` runner to `windows-2025-vs2026` (Windows Server 2025 + Visual Studio 2026), the current generation of GitHub-hosted Windows image.

`windows-2022` is not deprecated (supported ~3 more years), so this is a proactive upgrade rather than a forced migration. The explicit `vs2026` label is pinned instead of `windows-2025`/`windows-latest` so the toolchain stays fixed for reproducible installer builds, immune to future label re-pointing.

## Notes / risk

Qt stays on the `win64_msvc2022_64` prebuilt binary — the only Windows build Qt 6.10.2 ships (there is no `msvc2026` Qt build yet). MSVC maintains binary/ABI compatibility across major versions, so these binaries are expected to link and run under VS 2026, and `ilammy/msvc-dev-cmd` auto-detects whichever VS is installed. **This is the one thing that needs the CI run to confirm** before merging.

## Test plan

- [ ] Windows job builds and packages the MSI installer successfully on the new runner