### PR TITLE
Replace unmaintained msvc-dev-cmd with CMake VS generator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,10 +74,10 @@ jobs:
             , buildTarget: "--target package"
           }
         - {
-            name: "Windows", WIN_ARCH: "x64"
+            name: "Windows"
             , os: windows-2025-vs2026
             , QT_INST_DIR: "C:/", QT_ARCH: win64_msvc2022_64
-            , extraCMakeConfig: "-G Ninja"
+            , extraCMakeConfig: "-A x64"
             , buildTarget: "--target package"
           }
     steps:
@@ -95,12 +95,6 @@ jobs:
         submodules: true
         fetch-depth: 0
     - run: git fetch --tags --force
-
-    - name: Env Script (windows)
-      uses: ilammy/msvc-dev-cmd@v1
-      if: runner.os == 'Windows'
-      with:
-        arch: ${{matrix.config.WIN_ARCH}}
 
     - name: Import Signing Certificate ( windows )
       if: runner.os == 'Windows' && env.signWinRelease == 'true'
@@ -129,7 +123,6 @@ jobs:
         if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get update > /dev/null && sudo apt-get install -qqq libxcb-keysyms1-dev libxkbcommon-dev libxkbcommon-x11-dev libxcb-cursor0 > /dev/null
         elif [ "$RUNNER_OS" == "Windows" ]; then
-            choco install ninja --ignore-checksums
             # Install the latest WiX toolset (the `wix` CLI) used by the
             # `package` target to build the MSI installer, plus the UI
             # extension that provides the license-acceptance wizard. WiX v7
@@ -148,7 +141,7 @@ jobs:
         else
             cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release -DPACKAGE_VERSION="${{env.githash}}" ${{matrix.config.extraCMakeConfig}}
         fi
-        cmake --build build ${{ matrix.config.buildTarget }}
+        cmake --build build --config Release ${{ matrix.config.buildTarget }}
         cd build
         mkdir -p dist
         if [ "$RUNNER_OS" == "Linux" ]; then

--- a/deploy/CMakeLists.txt
+++ b/deploy/CMakeLists.txt
@@ -47,7 +47,7 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
 
     add_custom_target(package
         COMMAND ${CMAKE_COMMAND} -E rm -rf ${WIX_STAGE_DIR}
-        COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix ${WIX_STAGE_DIR}
+        COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix ${WIX_STAGE_DIR} --config $<CONFIG>
         COMMAND wix build -arch x64 -pdbtype none
                 -acceptEula wix7
                 -ext WixToolset.UI.wixext


### PR DESCRIPTION
## What

The Windows CI build relied on [`ilammy/msvc-dev-cmd`](https://github.com/ilammy/msvc-dev-cmd) (last released 2024-01-01, effectively unmaintained) to populate the MSVC `vcvars` environment. That was only necessary because the Windows build used the **Ninja** generator, which doesn't discover the MSVC toolchain on its own.

This switches the Windows build to CMake's default **Visual Studio** generator, which self-discovers MSVC — removing the need for the action (and the `choco install ninja` step) entirely.

## Changes

- Remove the `msvc-dev-cmd` step and the now-unused `WIN_ARCH` matrix var.
- Windows `extraCMakeConfig`: `-G Ninja` → `-A x64` (pin the platform to match the x64 Qt build under the default VS generator).
- Build with `--config Release` on every platform. The VS generator is multi-config and ignores `CMAKE_BUILD_TYPE`, while single-config generators (Linux/macOS) ignore `--config`, so the build command stays uniform across the matrix.
- Make the WiX `package` target's install multi-config-aware via `--config $<CONFIG>` so it locates the Release binary.

## Notes

- Could not build locally (Qt 6.10 unavailable in the dev env), so this PR exists to validate via CI — the Windows job is the thing to watch.
- Minor cosmetic effect: the VS generator emits an `ashirt.sln` in the build dir, which the broad `mv ashirt*.* dist/` sweeps into the CI artifact alongside the `.msi`. It does **not** reach Releases (those filter on `ashirt-*/ashirt-*.*`). Can tighten the glob if we care.