### PR TITLE
Adopt Qt 6.5 color-scheme API and chrono timer literals

### DIFF
--- a/src/forms/firstRunWizard/hosttestpage.cpp
+++ b/src/forms/firstRunWizard/hosttestpage.cpp
@@ -8,6 +8,7 @@
 #include <QTimer>
 #include <QNetworkReply>
 #include <QCheckBox>
+#include <chrono>
 
 #include "helpers/netman.h"
 
@@ -147,7 +148,7 @@ void HostTestPage::timerCheck()
   if(wizard()->currentId() == id()) {
     f=0;
     if (currentState == NetMan::TestResult::INPROGRESS)
-      timer->start(33);
+      timer->start(std::chrono::milliseconds(33));
     else
       timer->stop();
   }

--- a/src/forms/firstRunWizard/wizardpage.cpp
+++ b/src/forms/firstRunWizard/wizardpage.cpp
@@ -1,7 +1,8 @@
 #include "wizardpage.h"
+#include <QGuiApplication>
 #include <QPen>
 #include <QPainter>
-#include <QEvent>
+#include <QStyleHints>
 #include "system_helpers.h"
 
 WizardPage::WizardPage(int pageId, QWidget *parent)
@@ -14,17 +15,12 @@ WizardPage::WizardPage(int pageId, QWidget *parent)
 
   setPixmap(QWizard::WatermarkPixmap,  paintSideImage(m_id));
   setStyleSheet(isDarkMode() ? _darkStyle : _lightStyle);
-}
 
-void WizardPage::changeEvent(QEvent *event)
-{
-  if (event->type() == QEvent::PaletteChange) {
+  // Restyle and repaint when the system switches between light and dark themes.
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this, [this] {
     setStyleSheet(isDarkMode() ? _darkStyle : _lightStyle);
-    setPixmap(QWizard::WatermarkPixmap,  paintSideImage(m_id));
-    event->accept();
-    return;
-  }
-  event->ignore();
+    setPixmap(QWizard::WatermarkPixmap, paintSideImage(m_id));
+  });
 }
 
 bool WizardPage::isDarkMode()

--- a/src/forms/firstRunWizard/wizardpage.h
+++ b/src/forms/firstRunWizard/wizardpage.h
@@ -22,7 +22,6 @@ class WizardPage : public QWizardPage
   WizardPage(int pageId = Page_Requiments, QWidget *parent = nullptr);
   int id() {return m_id;}
  protected:
-  void changeEvent(QEvent *event);
   bool isDarkMode();
 #ifdef Q_OS_MAC
   const QPair<int, QFont::Weight> titleFont = QPair<int, QFont::Weight>(28, QFont::Bold);

--- a/src/helpers/system_helpers.h
+++ b/src/helpers/system_helpers.h
@@ -1,13 +1,8 @@
 #pragma once
 
 #include <QDir>
-
-#ifdef Q_OS_WIN
-#include <QSettings>
-#else
 #include <QtGui/QGuiApplication>
-#include <QtGui/QPalette>
-#endif
+#include <QtGui/QStyleHints>
 
 #include "appconfig.h"
 
@@ -28,11 +23,8 @@ class SystemHelpers {
     return root;
   }
   static bool isLightTheme() {
-#ifdef Q_OS_WIN
-    QSettings settings(QStringLiteral("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"), QSettings::NativeFormat);
-    return settings.value(QStringLiteral("SystemUsesLightTheme")).toInt() == 1;
-#else
-    return qApp->palette().text().color().value() <= QColor(Qt::lightGray).value();
-#endif
+    // QStyleHints::colorScheme() (Qt 6.5+) reports the platform theme directly
+    // on Windows, macOS, and Linux. Treat an Unknown scheme as light.
+    return QGuiApplication::styleHints()->colorScheme() != Qt::ColorScheme::Dark;
   }
 };

--- a/src/traymanager.cpp
+++ b/src/traymanager.cpp
@@ -10,7 +10,9 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QMimeData>
+#include <QStyleHints>
 #include <QTimer>
+#include <chrono>
 #include <QDesktopServices>
 #include <iostream>
 #include "appconfig.h"
@@ -41,15 +43,16 @@ TrayManager::TrayManager(QWidget * parent, DatabaseConnection* db)
     , allOperationActions(this)
 
 {
+  using namespace std::chrono_literals;
   HotkeyManager::updateHotkeys();
-  updateCheckTimer->start(MS_IN_DAY); // every day
+  updateCheckTimer->start(24h);
 
   buildUi();
   wireUi();
 
   // delayed so that windows can listen for get all ops signal
   NetMan::refreshOperationsList();
-  QTimer::singleShot(5000, this, &TrayManager::checkForUpdate);
+  QTimer::singleShot(5s, this, &TrayManager::checkForUpdate);
 
   if(AppConfig::value(CONFIG::SHOW_WELCOME_SCREEN) != "false")
     showWelcomeScreen();
@@ -126,6 +129,10 @@ void TrayManager::wireUi() {
   });
 
   connect(updateCheckTimer, &QTimer::timeout, this, &TrayManager::checkForUpdate);
+
+  // Swap the tray icon when the system switches between light and dark themes.
+  connect(qApp->styleHints(), &QStyleHints::colorSchemeChanged, this,
+          [this] { trayIcon->setIcon(getTrayIcon()); });
 }
 
 void TrayManager::cleanChooseOpSubmenu() {
@@ -147,15 +154,6 @@ void TrayManager::closeEvent(QCloseEvent* event) {
     hide();
     event->ignore();
   }
-}
-
-void TrayManager::changeEvent(QEvent *event)
-{
-  if (event->type() == QEvent::PaletteChange) {
-    trayIcon->setIcon(getTrayIcon());
-    event->accept();
-  }
-  event->ignore();
 }
 
 void TrayManager::showWizard()

--- a/src/traymanager.h
+++ b/src/traymanager.h
@@ -81,10 +81,8 @@ class TrayManager : public QDialog {
 
  protected:
   void closeEvent(QCloseEvent *event) override;
-  void changeEvent(QEvent *event) override;
 
  private:
-  inline static const int MS_IN_DAY = 86400000;
   QString _recordErrorTitle = tr("Unable to Record Evidence");
   DatabaseConnection *db = nullptr;
   Screenshot *screenshotTool = nullptr;


### PR DESCRIPTION
## Summary

Two Qt modernizations the recent C++23 pass (#275) left untouched, since it focused on language-level cleanup rather than Qt-API idioms.

### 1. `QStyleHints::colorScheme()` (Qt 6.5+)

- **`system_helpers.h`** — `isLightTheme()` previously inferred the theme two different ways: a palette-luminance heuristic on Unix (`palette().text().color().value() <= lightGray`) and a direct `Personalize\SystemUsesLightTheme` registry read on Windows. Both are replaced by a single cross-platform `QGuiApplication::styleHints()->colorScheme() != Qt::ColorScheme::Dark`.
- **`traymanager.{cpp,h}`** and **`wizardpage.{cpp,h}`** — removed the `changeEvent()`/`QEvent::PaletteChange` overrides and instead `connect()` to the precise `QStyleHints::colorSchemeChanged` signal. `PaletteChange` fired on many palette events unrelated to a light/dark switch; the signal fires only on an actual scheme change.

### 2. `std::chrono` timer literals

- `updateCheckTimer->start(MS_IN_DAY)` → `start(24h)` (drops the now-unused `MS_IN_DAY` constant)
- `QTimer::singleShot(5000, …)` → `singleShot(5s, …)`
- host-test spinner `timer->start(33)` → `start(std::chrono::milliseconds(33))`

Left `QStringLiteral` → `u"…"_s` alone — not deprecated, no behavioral/perf difference, and a 400+ line churn diff for no functional gain.

## Testing

Compiles, links, and is **warning-free** against Qt 6.10.2 (matching CI) in a Docker build.